### PR TITLE
Add package conflict resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SHELL := /bin/bash
-.PHONY: all iso iso-netinst iso-offline package sbom clean test help
+.PHONY: all iso iso-netinst iso-offline package sbom clean test test-conflicts help
 
 # Build configuration
 CODENAME := trixie
@@ -37,6 +37,7 @@ help:
 	@echo "  package PKG=x Build specific package (cx-core, cx-full, cx-archive-keyring)"
 	@echo "  sbom          Generate Software Bill of Materials"
 	@echo "  test          Run build verification tests"
+	@echo "  test-conflicts Run package conflict resolver tests"
 	@echo "  clean         Remove build artifacts"
 	@echo "  deps          Install build dependencies"
 	@echo ""
@@ -161,6 +162,10 @@ test:
 	./tests/verify-packages.sh || true
 	./tests/verify-preseed.sh || true
 	@echo -e "$(GREEN)Tests complete$(NC)"
+
+test-conflicts:
+	@echo -e "$(GREEN)Running package conflict resolver tests...$(NC)"
+	./tests/resolve-conflicts-test.sh
 
 # Clean build artifacts
 clean:

--- a/apt/README.md
+++ b/apt/README.md
@@ -81,6 +81,59 @@ git commit -m "Add mypackage 1.0.0"
 git push
 ```
 
+## Package Conflict Checks
+
+`apt/scripts/resolve-conflicts.py` checks a planned install list before it is
+passed to the package manager. It reads normal APT `Conflicts` and `Breaks`
+metadata, and it can also read a small JSON rules file for CX-specific choices.
+
+Example:
+
+```bash
+apt/scripts/resolve-conflicts.py \
+  --rules ./package-conflicts.json \
+  docker.io podman
+```
+
+Example rules file:
+
+```json
+{
+  "conflicts": [
+    {
+      "packages": ["docker.io", "podman"],
+      "reason": "Both packages manage the default container runtime socket.",
+      "options": ["docker.io", "podman"]
+    }
+  ]
+}
+```
+
+The helper exits with status `1` when conflicts are found. A user choice can be
+saved and reused later:
+
+```bash
+apt/scripts/resolve-conflicts.py \
+  --rules ./package-conflicts.json \
+  --choice podman \
+  docker.io podman
+```
+
+For an interactive prompt:
+
+```bash
+apt/scripts/resolve-conflicts.py --interactive docker.io podman
+```
+
+In the installed `cx-core` package this is exposed through the wrapper:
+
+```bash
+cx resolve-conflicts docker.io podman
+```
+
+`cx install package-a package-b` also runs the same preflight check before it
+hands off to the Python package manager.
+
 ### Method 2: Workflow dispatch
 
 Go to Actions → Publish APT Repository → Run workflow

--- a/apt/scripts/resolve-conflicts.py
+++ b/apt/scripts/resolve-conflicts.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Detect and explain package conflicts before install.
+
+This helper is intentionally small and dependency-free so it can run from the
+cx-core package before the Python cx CLI is installed from PyPI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+APT_RELATION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+.-]+")
+
+
+@dataclass(frozen=True)
+class Conflict:
+    packages: tuple[str, ...]
+    reason: str
+    options: tuple[str, ...]
+    source: str
+
+    @property
+    def key(self) -> str:
+        return "|".join(sorted(self.packages))
+
+
+def parse_relation_names(value: str) -> set[str]:
+    names: set[str] = set()
+    for part in value.split(","):
+        match = APT_RELATION_RE.search(part.strip())
+        if match:
+            names.add(match.group(0))
+    return names
+
+
+def read_apt_fields(package: str) -> dict[str, list[str]]:
+    try:
+        result = subprocess.run(
+            ["apt-cache", "show", package],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return {}
+
+    fields: dict[str, list[str]] = {}
+    current_key = ""
+    for line in result.stdout.splitlines():
+        if not line:
+            current_key = ""
+            continue
+        if line[0].isspace() and current_key:
+            fields[current_key][-1] += " " + line.strip()
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        current_key = key.strip()
+        fields.setdefault(current_key, []).append(value.strip())
+    return fields
+
+
+def detect_apt_conflicts(packages: list[str]) -> list[Conflict]:
+    requested = set(packages)
+    conflicts: dict[str, Conflict] = {}
+
+    for package in packages:
+        fields = read_apt_fields(package)
+        related: set[str] = set()
+        for field in ("Conflicts", "Breaks"):
+            for value in fields.get(field, []):
+                related.update(parse_relation_names(value))
+
+        overlap = sorted((related & requested) - {package})
+        for other in overlap:
+            package_pair = tuple(sorted((package, other)))
+            conflict = Conflict(
+                packages=package_pair,
+                reason=f"{package} cannot be installed together with {other}",
+                options=package_pair,
+                source="apt-cache",
+            )
+            conflicts[conflict.key] = conflict
+
+    return list(conflicts.values())
+
+
+def load_rule_conflicts(path: Path, packages: list[str]) -> list[Conflict]:
+    if not path.exists():
+        return []
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    requested = set(packages)
+    found: list[Conflict] = []
+    for item in data.get("conflicts", []):
+        item_packages = tuple(str(pkg) for pkg in item.get("packages", []))
+        if len(item_packages) < 2:
+            continue
+        if set(item_packages).issubset(requested):
+            options = tuple(str(option) for option in item.get("options", item_packages))
+            found.append(
+                Conflict(
+                    packages=tuple(sorted(item_packages)),
+                    reason=str(item.get("reason", "Packages cannot be installed together")),
+                    options=options,
+                    source=str(path),
+                )
+            )
+    return found
+
+
+def load_preferences(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def save_preference(path: Path, key: str, choice: str) -> None:
+    data = load_preferences(path)
+    data[key] = choice
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def conflict_to_dict(conflict: Conflict, saved_choice: str | None) -> dict[str, object]:
+    return {
+        "packages": list(conflict.packages),
+        "reason": conflict.reason,
+        "options": list(conflict.options),
+        "source": conflict.source,
+        "saved_choice": saved_choice,
+    }
+
+
+def print_human(conflicts: Iterable[Conflict], preferences: dict[str, str]) -> None:
+    conflict_list = list(conflicts)
+    if not conflict_list:
+        print("No package conflicts found.")
+        return
+
+    print("Package conflicts found:")
+    for index, conflict in enumerate(conflict_list, start=1):
+        print(f"\n{index}. {' vs '.join(conflict.packages)}")
+        print(f"   Reason: {conflict.reason}")
+        saved_choice = preferences.get(conflict.key)
+        if saved_choice:
+            print(f"   Saved preference: keep {saved_choice}")
+        print("   Options:")
+        for option_index, option in enumerate(conflict.options, start=1):
+            print(f"     {option_index}) keep {option}")
+
+
+def prompt_for_choices(conflicts: Iterable[Conflict], preferences_path: Path) -> dict[str, str]:
+    saved: dict[str, str] = {}
+    for conflict in conflicts:
+        print(f"\nConflict: {' vs '.join(conflict.packages)}")
+        print(f"Reason: {conflict.reason}")
+        for option_index, option in enumerate(conflict.options, start=1):
+            print(f"  {option_index}) keep {option}")
+        print("  s) skip for now")
+
+        while True:
+            try:
+                answer = input(f"Select option [1-{len(conflict.options)} or s]: ").strip()
+            except EOFError:
+                print("\nNo selection made.", file=sys.stderr)
+                break
+
+            if answer.lower() == "s":
+                break
+            if answer.isdigit():
+                selected_index = int(answer) - 1
+                if 0 <= selected_index < len(conflict.options):
+                    choice = conflict.options[selected_index]
+                    save_preference(preferences_path, conflict.key, choice)
+                    saved[conflict.key] = choice
+                    print(f"Saved preference: keep {choice}")
+                    break
+            print("Please enter a listed option.")
+    return saved
+
+
+def default_preferences_path() -> Path:
+    return Path(
+        os.environ.get(
+            "CX_CONFLICT_PREFERENCES",
+            Path.home() / ".config" / "cx" / "conflict-preferences.json",
+        )
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect package conflicts and save a preferred resolution."
+    )
+    parser.add_argument("packages", nargs="+", help="Packages planned for install")
+    parser.add_argument(
+        "--rules",
+        default="/etc/cx/package-conflicts.json",
+        help="Optional JSON conflict rules file",
+    )
+    parser.add_argument(
+        "--preferences",
+        default=str(default_preferences_path()),
+        help="Saved preference file",
+    )
+    parser.add_argument("--choice", help="Save this package as the preferred option")
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Prompt for a preferred option for each conflict",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    preferences_path = Path(args.preferences).expanduser()
+    preferences = load_preferences(preferences_path)
+
+    conflicts = detect_apt_conflicts(args.packages)
+    conflicts.extend(load_rule_conflicts(Path(args.rules), args.packages))
+    conflicts = sorted(
+        {conflict.key: conflict for conflict in conflicts}.values(),
+        key=lambda item: item.key,
+    )
+
+    if args.choice:
+        matching = [conflict for conflict in conflicts if args.choice in conflict.options]
+        if not matching:
+            print(f"Choice '{args.choice}' does not match any conflict option.", file=sys.stderr)
+            return 2
+        for conflict in matching:
+            save_preference(preferences_path, conflict.key, args.choice)
+            preferences[conflict.key] = args.choice
+
+    if args.interactive and conflicts:
+        preferences.update(prompt_for_choices(conflicts, preferences_path))
+
+    if args.json:
+        payload = {
+            "ok": not conflicts,
+            "conflicts": [
+                conflict_to_dict(conflict, preferences.get(conflict.key))
+                for conflict in conflicts
+            ],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_human(conflicts, preferences)
+
+    return 1 if conflicts else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/apt/scripts/resolve-conflicts.py
+++ b/apt/scripts/resolve-conflicts.py
@@ -14,12 +14,14 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
 
 APT_RELATION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+.-]+")
+APT_CACHE = Path("/usr/bin/apt-cache")
 
 
 @dataclass(frozen=True)
@@ -47,9 +49,12 @@ def parse_relation_names(value: str) -> set[str]:
 
 def read_apt_fields(package: str) -> dict[str, list[str]]:
     """Read fields from apt-cache show for one package."""
+    if not APT_CACHE.is_file() or not os.access(APT_CACHE, os.X_OK):
+        return {}
+
     try:
         result = subprocess.run(
-            ["apt-cache", "show", package],
+            [str(APT_CACHE), "show", package],
             check=False,
             capture_output=True,
             text=True,
@@ -113,14 +118,28 @@ def load_rule_conflicts(path: Path, packages: list[str]) -> list[Conflict]:
         print(f"Warning: could not read rules file {path}: {exc}", file=sys.stderr)
         return []
 
+    if not isinstance(data, dict):
+        return []
+    items = data.get("conflicts", [])
+    if not isinstance(items, list):
+        return []
+
     requested = set(packages)
     found: list[Conflict] = []
-    for item in data.get("conflicts", []):
-        item_packages = tuple(str(pkg) for pkg in item.get("packages", []))
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        raw_packages = item.get("packages", [])
+        if not isinstance(raw_packages, list):
+            continue
+        item_packages = tuple(str(pkg) for pkg in raw_packages)
         if len(item_packages) < 2:
             continue
         if set(item_packages).issubset(requested):
-            options = tuple(str(option) for option in item.get("options", item_packages))
+            raw_options = item.get("options", item_packages)
+            if not isinstance(raw_options, (list, tuple)):
+                raw_options = item_packages
+            options = tuple(str(option) for option in raw_options)
             found.append(
                 Conflict(
                     packages=tuple(sorted(item_packages)),
@@ -156,9 +175,24 @@ def save_preference(path: Path, key: str, choice: str) -> None:
 def save_preferences(path: Path, data: dict[str, str]) -> None:
     """Persist all saved choices in one write."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(data, handle, indent=2, sort_keys=True)
-        handle.write("\n")
+    temp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as handle:
+            temp_path = handle.name
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    finally:
+        if temp_path and Path(temp_path).exists():
+            Path(temp_path).unlink()
 
 
 def conflict_to_dict(conflict: Conflict, saved_choice: str | None) -> dict[str, object]:

--- a/apt/scripts/resolve-conflicts.py
+++ b/apt/scripts/resolve-conflicts.py
@@ -24,6 +24,8 @@ APT_RELATION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+.-]+")
 
 @dataclass(frozen=True)
 class Conflict:
+    """One conflict found between requested packages."""
+
     packages: tuple[str, ...]
     reason: str
     options: tuple[str, ...]
@@ -31,10 +33,12 @@ class Conflict:
 
     @property
     def key(self) -> str:
+        """Stable key used for saved choices and duplicate removal."""
         return "|".join(sorted(self.packages))
 
 
 def parse_relation_names(value: str) -> set[str]:
+    """Extract package names from an apt relationship field."""
     names: set[str] = set()
     for part in value.split(","):
         names.update(APT_RELATION_RE.findall(part.strip()))
@@ -42,6 +46,7 @@ def parse_relation_names(value: str) -> set[str]:
 
 
 def read_apt_fields(package: str) -> dict[str, list[str]]:
+    """Read fields from apt-cache show for one package."""
     try:
         result = subprocess.run(
             ["apt-cache", "show", package],
@@ -71,6 +76,7 @@ def read_apt_fields(package: str) -> dict[str, list[str]]:
 
 
 def detect_apt_conflicts(packages: list[str]) -> list[Conflict]:
+    """Find conflicts reported by apt metadata for the requested packages."""
     requested = set(packages)
     conflicts: dict[str, Conflict] = {}
 
@@ -96,6 +102,7 @@ def detect_apt_conflicts(packages: list[str]) -> list[Conflict]:
 
 
 def load_rule_conflicts(path: Path, packages: list[str]) -> list[Conflict]:
+    """Load extra conflict rules from JSON when the file is available."""
     if not path.exists():
         return []
 
@@ -126,6 +133,7 @@ def load_rule_conflicts(path: Path, packages: list[str]) -> list[Conflict]:
 
 
 def load_preferences(path: Path) -> dict[str, str]:
+    """Load saved conflict choices from disk."""
     if not path.exists():
         return {}
     try:
@@ -139,6 +147,7 @@ def load_preferences(path: Path) -> dict[str, str]:
 
 
 def save_preference(path: Path, key: str, choice: str) -> None:
+    """Persist one saved choice while keeping existing choices."""
     data = load_preferences(path)
     data[key] = choice
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -148,6 +157,7 @@ def save_preference(path: Path, key: str, choice: str) -> None:
 
 
 def conflict_to_dict(conflict: Conflict, saved_choice: str | None) -> dict[str, object]:
+    """Convert a conflict to the JSON output shape."""
     return {
         "packages": list(conflict.packages),
         "reason": conflict.reason,
@@ -158,6 +168,7 @@ def conflict_to_dict(conflict: Conflict, saved_choice: str | None) -> dict[str, 
 
 
 def print_human(conflicts: Iterable[Conflict], preferences: dict[str, str]) -> None:
+    """Print the normal terminal output."""
     conflict_list = list(conflicts)
     if not conflict_list:
         print("No package conflicts found.")
@@ -176,6 +187,7 @@ def print_human(conflicts: Iterable[Conflict], preferences: dict[str, str]) -> N
 
 
 def prompt_for_choices(conflicts: Iterable[Conflict], preferences_path: Path) -> dict[str, str]:
+    """Ask the user which package to keep for each conflict."""
     saved: dict[str, str] = {}
     for conflict in conflicts:
         print(f"\nConflict: {' vs '.join(conflict.packages)}")
@@ -206,6 +218,7 @@ def prompt_for_choices(conflicts: Iterable[Conflict], preferences_path: Path) ->
 
 
 def default_preferences_path() -> Path:
+    """Return the default path for saved conflict preferences."""
     return Path(
         os.environ.get(
             "CX_CONFLICT_PREFERENCES",
@@ -215,6 +228,7 @@ def default_preferences_path() -> Path:
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         description="Detect package conflicts and save a preferred resolution."
     )
@@ -240,6 +254,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str]) -> int:
+    """Run the conflict resolver command."""
     args = parse_args(argv)
     preferences_path = Path(args.preferences).expanduser()
     preferences = load_preferences(preferences_path)

--- a/apt/scripts/resolve-conflicts.py
+++ b/apt/scripts/resolve-conflicts.py
@@ -37,9 +37,7 @@ class Conflict:
 def parse_relation_names(value: str) -> set[str]:
     names: set[str] = set()
     for part in value.split(","):
-        match = APT_RELATION_RE.search(part.strip())
-        if match:
-            names.add(match.group(0))
+        names.update(APT_RELATION_RE.findall(part.strip()))
     return names
 
 
@@ -101,8 +99,12 @@ def load_rule_conflicts(path: Path, packages: list[str]) -> list[Conflict]:
     if not path.exists():
         return []
 
-    with path.open("r", encoding="utf-8") as handle:
-        data = json.load(handle)
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Warning: could not read rules file {path}: {exc}", file=sys.stderr)
+        return []
 
     requested = set(packages)
     found: list[Conflict] = []
@@ -243,7 +245,7 @@ def main(argv: list[str]) -> int:
     preferences = load_preferences(preferences_path)
 
     conflicts = detect_apt_conflicts(args.packages)
-    conflicts.extend(load_rule_conflicts(Path(args.rules), args.packages))
+    conflicts.extend(load_rule_conflicts(Path(args.rules).expanduser(), args.packages))
     conflicts = sorted(
         {conflict.key: conflict for conflict in conflicts}.values(),
         key=lambda item: item.key,

--- a/apt/scripts/resolve-conflicts.py
+++ b/apt/scripts/resolve-conflicts.py
@@ -80,7 +80,7 @@ def detect_apt_conflicts(packages: list[str]) -> list[Conflict]:
     requested = set(packages)
     conflicts: dict[str, Conflict] = {}
 
-    for package in packages:
+    for package in requested:
         fields = read_apt_fields(package)
         related: set[str] = set()
         for field in ("Conflicts", "Breaks"):
@@ -150,6 +150,11 @@ def save_preference(path: Path, key: str, choice: str) -> None:
     """Persist one saved choice while keeping existing choices."""
     data = load_preferences(path)
     data[key] = choice
+    save_preferences(path, data)
+
+
+def save_preferences(path: Path, data: dict[str, str]) -> None:
+    """Persist all saved choices in one write."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
         json.dump(data, handle, indent=2, sort_keys=True)
@@ -272,8 +277,8 @@ def main(argv: list[str]) -> int:
             print(f"Choice '{args.choice}' does not match any conflict option.", file=sys.stderr)
             return 2
         for conflict in matching:
-            save_preference(preferences_path, conflict.key, args.choice)
             preferences[conflict.key] = args.choice
+        save_preferences(preferences_path, preferences)
 
     if args.interactive and conflicts:
         preferences.update(prompt_for_choices(conflicts, preferences_path))

--- a/packages/cx-core/debian/rules
+++ b/packages/cx-core/debian/rules
@@ -25,10 +25,19 @@ override_dh_auto_install:
 	# Install default configuration
 	install -m 644 debian/cx.yaml \
 		$(CURDIR)/debian/cx-core/etc/cx/cx.yaml
+	install -m 755 ../../apt/scripts/resolve-conflicts.py \
+		$(CURDIR)/debian/cx-core/usr/share/cx/resolve-conflicts.py
 
 	# Create cx wrapper that installs from PyPI on first run
 	echo '#!/bin/bash' > $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo '# CX Linux CLI Wrapper' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo 'if [ "$$1" = "resolve-conflicts" ]; then' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    shift' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    exec python3 /usr/share/cx/resolve-conflicts.py "$$@"' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo 'fi' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo 'if [ "$$1" = "install" ] && [ "$$#" -gt 2 ]; then' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    python3 /usr/share/cx/resolve-conflicts.py "$${@:2}" || exit $$?' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo 'fi' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo 'if ! python3 -c "import cx" 2>/dev/null; then' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo '    echo "Installing cx-linux from PyPI..."' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo '    pip3 install --user cx-linux' >> $(CURDIR)/debian/cx-core/usr/bin/cx

--- a/packages/cx-core/debian/rules
+++ b/packages/cx-core/debian/rules
@@ -35,8 +35,14 @@ override_dh_auto_install:
 	echo '    shift' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo '    exec python3 /usr/share/cx/resolve-conflicts.py "$$@"' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo 'fi' >> $(CURDIR)/debian/cx-core/usr/bin/cx
-	echo 'if [ "$$1" = "install" ] && [ "$$#" -gt 2 ]; then' >> $(CURDIR)/debian/cx-core/usr/bin/cx
-	echo '    python3 /usr/share/cx/resolve-conflicts.py "$${@:2}" || exit $$?' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo 'if [ "$$1" = "install" ]; then' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    cx_install_operands=0' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    for cx_arg in "$${@:2}"; do' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '        case "$$cx_arg" in -*) ;; *) cx_install_operands=$$((cx_install_operands + 1)) ;; esac' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    done' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    if [ "$$cx_install_operands" -gt 1 ]; then' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '        python3 /usr/share/cx/resolve-conflicts.py "$${@:2}" || exit $$?' >> $(CURDIR)/debian/cx-core/usr/bin/cx
+	echo '    fi' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo 'fi' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo 'if ! python3 -c "import cx" 2>/dev/null; then' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	echo '    echo "Installing cx-linux from PyPI..."' >> $(CURDIR)/debian/cx-core/usr/bin/cx

--- a/tests/resolve-conflicts-test.sh
+++ b/tests/resolve-conflicts-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+RULES_FILE="$TMP_DIR/conflicts.json"
+PREFS_FILE="$TMP_DIR/preferences.json"
+
+cat > "$RULES_FILE" <<'JSON'
+{
+  "conflicts": [
+    {
+      "packages": ["docker.io", "podman"],
+      "reason": "Both packages manage the default container runtime socket.",
+      "options": ["docker.io", "podman"]
+    }
+  ]
+}
+JSON
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "Expected output to contain: $needle" >&2
+        echo "$haystack" >&2
+        exit 1
+    fi
+}
+
+set +e
+OUTPUT="$("$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$RULES_FILE" \
+    --preferences "$PREFS_FILE" \
+    docker.io podman 2>&1)"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 1 ]]; then
+    echo "Expected conflict status 1, got $STATUS" >&2
+    echo "$OUTPUT" >&2
+    exit 1
+fi
+
+assert_contains "$OUTPUT" "Package conflicts found"
+assert_contains "$OUTPUT" "docker.io vs podman"
+assert_contains "$OUTPUT" "keep docker.io"
+assert_contains "$OUTPUT" "keep podman"
+
+"$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$RULES_FILE" \
+    --preferences "$PREFS_FILE" \
+    --choice podman \
+    docker.io podman >/dev/null || true
+
+SAVED="$(cat "$PREFS_FILE")"
+assert_contains "$SAVED" "\"docker.io|podman\": \"podman\""
+
+JSON_OUTPUT="$("$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$RULES_FILE" \
+    --preferences "$PREFS_FILE" \
+    --json \
+    docker.io podman || true)"
+assert_contains "$JSON_OUTPUT" "\"saved_choice\": \"podman\""
+
+INTERACTIVE_OUTPUT="$(printf '1\n' | "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$RULES_FILE" \
+    --preferences "$PREFS_FILE" \
+    --interactive \
+    docker.io podman || true)"
+assert_contains "$INTERACTIVE_OUTPUT" "Select option"
+assert_contains "$INTERACTIVE_OUTPUT" "Saved preference: keep docker.io"
+
+NO_CONFLICT_OUTPUT="$("$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$RULES_FILE" \
+    --preferences "$PREFS_FILE" \
+    nginx curl)"
+assert_contains "$NO_CONFLICT_OUTPUT" "No package conflicts found."
+
+echo "resolve-conflicts tests passed"

--- a/tests/resolve-conflicts-test.sh
+++ b/tests/resolve-conflicts-test.sh
@@ -82,6 +82,22 @@ MALFORMED_OUTPUT="$(python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
 assert_contains "$MALFORMED_OUTPUT" "Warning: could not read rules file"
 assert_contains "$MALFORMED_OUTPUT" "No package conflicts found."
 
+cat > "$TMP_DIR/bad-schema.json" <<'JSON'
+{
+  "conflicts": [
+    42,
+    {"packages": "nginx"},
+    {"packages": ["nginx", "curl"], "options": "nginx"}
+  ]
+}
+JSON
+BAD_SCHEMA_OUTPUT="$(python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$TMP_DIR/bad-schema.json" \
+    --preferences "$PREFS_FILE" \
+    nginx curl 2>&1 || true)"
+assert_contains "$BAD_SCHEMA_OUTPUT" "Package conflicts found"
+assert_contains "$BAD_SCHEMA_OUTPUT" "curl vs nginx"
+
 INTERACTIVE_OUTPUT="$(printf '1\n' | python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
     --rules "$RULES_FILE" \
     --preferences "$PREFS_FILE" \

--- a/tests/resolve-conflicts-test.sh
+++ b/tests/resolve-conflicts-test.sh
@@ -32,7 +32,7 @@ assert_contains() {
 }
 
 set +e
-OUTPUT="$("$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+OUTPUT="$(python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
     --rules "$RULES_FILE" \
     --preferences "$PREFS_FILE" \
     docker.io podman 2>&1)"
@@ -50,7 +50,7 @@ assert_contains "$OUTPUT" "docker.io vs podman"
 assert_contains "$OUTPUT" "keep docker.io"
 assert_contains "$OUTPUT" "keep podman"
 
-"$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
     --rules "$RULES_FILE" \
     --preferences "$PREFS_FILE" \
     --choice podman \
@@ -59,14 +59,30 @@ assert_contains "$OUTPUT" "keep podman"
 SAVED="$(cat "$PREFS_FILE")"
 assert_contains "$SAVED" "\"docker.io|podman\": \"podman\""
 
-JSON_OUTPUT="$("$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+JSON_OUTPUT="$(python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
     --rules "$RULES_FILE" \
     --preferences "$PREFS_FILE" \
     --json \
     docker.io podman || true)"
 assert_contains "$JSON_OUTPUT" "\"saved_choice\": \"podman\""
 
-INTERACTIVE_OUTPUT="$(printf '1\n' | "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+python3 -c "import importlib.util, sys; spec = importlib.util.spec_from_file_location('resolver', '$ROOT_DIR/apt/scripts/resolve-conflicts.py'); mod = importlib.util.module_from_spec(spec); sys.modules['resolver'] = mod; spec.loader.exec_module(mod); assert mod.parse_relation_names('pkg-a | pkg-a-compat (>= 1), pkg-b') == {'pkg-a', 'pkg-a-compat', 'pkg-b'}"
+
+BROKEN_OUTPUT="$(python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$TMP_DIR/broken.json" \
+    --preferences "$PREFS_FILE" \
+    nginx curl 2>&1)"
+assert_contains "$BROKEN_OUTPUT" "No package conflicts found."
+
+printf '{broken json' > "$TMP_DIR/broken.json"
+MALFORMED_OUTPUT="$(python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+    --rules "$TMP_DIR/broken.json" \
+    --preferences "$PREFS_FILE" \
+    nginx curl 2>&1)"
+assert_contains "$MALFORMED_OUTPUT" "Warning: could not read rules file"
+assert_contains "$MALFORMED_OUTPUT" "No package conflicts found."
+
+INTERACTIVE_OUTPUT="$(printf '1\n' | python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
     --rules "$RULES_FILE" \
     --preferences "$PREFS_FILE" \
     --interactive \
@@ -74,7 +90,7 @@ INTERACTIVE_OUTPUT="$(printf '1\n' | "$ROOT_DIR/apt/scripts/resolve-conflicts.py
 assert_contains "$INTERACTIVE_OUTPUT" "Select option"
 assert_contains "$INTERACTIVE_OUTPUT" "Saved preference: keep docker.io"
 
-NO_CONFLICT_OUTPUT="$("$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
+NO_CONFLICT_OUTPUT="$(python3 "$ROOT_DIR/apt/scripts/resolve-conflicts.py" \
     --rules "$RULES_FILE" \
     --preferences "$PREFS_FILE" \
     nginx curl)"


### PR DESCRIPTION
Adds a small conflict resolver for planned package installs.

What changed:
- new apt/scripts/resolve-conflicts.py helper
- detects APT Conflicts/Breaks and optional CX json rules
- prints simple options and can save a selected package preference
- added `--interactive` prompt for choosing the preferred package
- cx wrapper exposes `cx resolve-conflicts ...`
- cx install with multiple packages runs the check before handing off
- docs and a focused shell test

Checks run:
- `python3 -m py_compile apt/scripts/resolve-conflicts.py`
- `bash -n tests/resolve-conflicts-test.sh`
- `make test-conflicts`
- `git diff --check`
- `git diff --cached --check`

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package conflict detection and resolution with interactive conflict selection and persistent preference storage.
  * Automatic preflight conflict checks integrated into package installation workflow.
  * New `resolve-conflicts` command available in the CLI.

* **Documentation**
  * Added comprehensive documentation covering conflict detection, resolution options, and practical usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cxlinux-ai/cx-distro/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->