### PR TITLE
feat: add package changelog viewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SHELL := /bin/bash
-.PHONY: all iso iso-netinst iso-offline package sbom clean test help
+.PHONY: all iso iso-netinst iso-offline package sbom clean test test-changelog help
 
 # Build configuration
 CODENAME := trixie
@@ -37,6 +37,7 @@ help:
 	@echo "  package PKG=x Build specific package (cx-core, cx-full, cx-archive-keyring)"
 	@echo "  sbom          Generate Software Bill of Materials"
 	@echo "  test          Run build verification tests"
+	@echo "  test-changelog Run changelog viewer unit tests"
 	@echo "  clean         Remove build artifacts"
 	@echo "  deps          Install build dependencies"
 	@echo ""
@@ -157,10 +158,14 @@ sbom:
 # Run tests
 test:
 	@echo -e "$(GREEN)Running build verification tests...$(NC)"
+	python3 -m unittest tests/test_changelog.py
 	./tests/verify-iso.sh $(OUTPUT_DIR)/$(ISO_NAME)-offline.iso || true
 	./tests/verify-packages.sh || true
 	./tests/verify-preseed.sh || true
 	@echo -e "$(GREEN)Tests complete$(NC)"
+
+test-changelog:
+	python3 -m unittest tests/test_changelog.py
 
 # Clean build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -180,9 +180,26 @@ make package        # Build all Debian packages
 make package PKG=cx-core  # Build specific package
 make sbom           # Generate SBOM
 make test           # Run verification tests
+make test-changelog # Run changelog viewer unit tests only
 make clean          # Remove build artifacts
 make deps           # Install build dependencies
 ```
+
+## Package changelog viewer
+
+Use the offline changelog helper to inspect Debian package changelogs kept under
+`packages/<package>/debian/changelog`:
+
+```bash
+python3 scripts/changelog.py cx-core
+python3 scripts/changelog.py cx-core --search security
+python3 scripts/changelog.py cx-core --security --export cx-core-security.json
+python3 scripts/changelog.py cx-core 0.1.0-1 0.1.1-1
+```
+
+The viewer formats release notes, searches change text and versions, compares a
+version range, highlights security-related fixes, and can export selected
+entries as JSON for release notes or audit handoff.
 
 ## Topics Covered
 

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -60,6 +60,7 @@ def parse_changelog(text: str) -> list[ChangelogEntry]:
     changes: list[str] = []
 
     def flush() -> None:
+        """Persist the current changelog block and reset parser state."""
         nonlocal current, changes
         if not current:
             return

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""View, search, compare, and export Debian package changelogs.
+
+The command is intentionally offline-first for distro-builder workflows: it reads
+local ``packages/<name>/debian/changelog`` files by default, while also allowing
+an explicit changelog file path for tests and ad-hoc package audits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, cast
+
+CHANGELOG_HEADER = re.compile(
+    r"^(?P<package>[\w.+-]+) \((?P<version>[^)]+)\) (?P<distribution>[^;]+); urgency=(?P<urgency>\S+)"
+)
+SECURITY_RE = re.compile(r"\b(CVE-\d{4}-\d{4,}|security|vulnerab|exploit|privilege|auth)\b", re.I)
+BULLET_RE = re.compile(r"^\s{2,}\*\s?(?P<text>.*)$")
+MAINTAINER_RE = re.compile(r"^ -- (?P<maintainer>.+?)  (?P<date>.+)$")
+
+
+@dataclass(frozen=True)
+class ChangelogEntry:
+    package: str
+    version: str
+    distribution: str
+    urgency: str
+    changes: tuple[str, ...]
+    maintainer: str = ""
+    date: str = ""
+
+    @property
+    def has_security_fix(self) -> bool:
+        return any(SECURITY_RE.search(change) for change in self.changes)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def default_changelog_path(package: str, root: Path | None = None) -> Path:
+    base = root or repo_root()
+    return base / "packages" / package / "debian" / "changelog"
+
+
+def parse_changelog(text: str) -> list[ChangelogEntry]:
+    entries: list[ChangelogEntry] = []
+    current: dict[str, object] | None = None
+    changes: list[str] = []
+
+    def flush() -> None:
+        nonlocal current, changes
+        if not current:
+            return
+        entries.append(
+            ChangelogEntry(
+                package=str(current["package"]),
+                version=str(current["version"]),
+                distribution=str(current["distribution"]),
+                urgency=str(current["urgency"]),
+                changes=tuple(changes),
+                maintainer=str(current.get("maintainer", "")),
+                date=str(current.get("date", "")),
+            )
+        )
+        current = None
+        changes = []
+
+    for raw_line in text.splitlines():
+        header = CHANGELOG_HEADER.match(raw_line)
+        if header:
+            flush()
+            current = cast(dict[str, object], header.groupdict())
+            continue
+        if current is None:
+            continue
+        maintainer = MAINTAINER_RE.match(raw_line)
+        if maintainer:
+            current.update(maintainer.groupdict())
+            flush()
+            continue
+        bullet = BULLET_RE.match(raw_line)
+        if bullet:
+            changes.append(bullet.group("text").strip())
+        elif changes and raw_line.startswith("    "):
+            changes[-1] = f"{changes[-1]} {raw_line.strip()}".strip()
+    flush()
+    return entries
+
+
+def load_entries(package: str, changelog: Path | None = None) -> list[ChangelogEntry]:
+    path = changelog or default_changelog_path(package)
+    if not path.exists():
+        raise FileNotFoundError(f"No changelog found for {package!r}: {path}")
+    return parse_changelog(path.read_text(encoding="utf-8"))
+
+
+def filter_entries(entries: Iterable[ChangelogEntry], query: str | None = None) -> list[ChangelogEntry]:
+    entries = list(entries)
+    if not query:
+        return entries
+    needle = query.lower()
+    return [entry for entry in entries if needle in entry.version.lower() or any(needle in change.lower() for change in entry.changes)]
+
+
+def compare_entries(entries: Iterable[ChangelogEntry], older: str, newer: str) -> list[ChangelogEntry]:
+    selected: list[ChangelogEntry] = []
+    capture = False
+    for entry in entries:
+        if entry.version == newer:
+            capture = True
+        if capture:
+            selected.append(entry)
+        if entry.version == older:
+            break
+    return selected
+
+
+def format_entries(entries: Iterable[ChangelogEntry]) -> str:
+    lines: list[str] = []
+    for entry in entries:
+        marker = "🔐 " if entry.has_security_fix else ""
+        lines.append(f"{marker}{entry.package} {entry.version} ({entry.date or entry.distribution})")
+        for change in entry.changes or ("No bullet items recorded.",):
+            prefix = "   🔐 Security:" if SECURITY_RE.search(change) else "   -"
+            lines.append(f"{prefix} {change}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def export_entries(entries: Iterable[ChangelogEntry], output: Path) -> None:
+    data = []
+    for entry in entries:
+        item = asdict(entry)
+        item["has_security_fix"] = entry.has_security_fix
+        data.append(item)
+    output.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="View/search package changelogs")
+    parser.add_argument("package", help="package directory name under packages/")
+    parser.add_argument("older", nargs="?", help="older version for compare mode")
+    parser.add_argument("newer", nargs="?", help="newer version for compare mode")
+    parser.add_argument("--file", type=Path, help="read a specific changelog file")
+    parser.add_argument("--search", help="filter changes by text or version")
+    parser.add_argument("--security", action="store_true", help="show only entries with security-related changes")
+    parser.add_argument("--export", type=Path, help="write selected entries as JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        entries = load_entries(args.package, args.file)
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    if args.older or args.newer:
+        if not (args.older and args.newer):
+            print("compare mode requires both older and newer versions", file=sys.stderr)
+            return 2
+        entries = compare_entries(entries, args.older, args.newer)
+
+    entries = filter_entries(entries, args.search)
+    if args.security:
+        entries = [entry for entry in entries if entry.has_security_fix]
+
+    if args.export:
+        export_entries(entries, args.export)
+
+    output = format_entries(entries)
+    if output:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -26,6 +26,8 @@ MAINTAINER_RE = re.compile(r"^ -- (?P<maintainer>.+?)\s{2,}(?P<date>.+)$")
 
 @dataclass(frozen=True)
 class ChangelogEntry:
+    """Structured representation of one Debian changelog release block."""
+
     package: str
     version: str
     distribution: str
@@ -36,19 +38,23 @@ class ChangelogEntry:
 
     @property
     def has_security_fix(self) -> bool:
+        """Return whether any recorded change looks security-related."""
         return any(SECURITY_RE.search(change) for change in self.changes)
 
 
 def repo_root() -> Path:
+    """Return the repository root relative to this helper script."""
     return Path(__file__).resolve().parents[1]
 
 
 def default_changelog_path(package: str, root: Path | None = None) -> Path:
+    """Build the conventional local Debian changelog path for a package."""
     base = root or repo_root()
     return base / "packages" / package / "debian" / "changelog"
 
 
 def parse_changelog(text: str) -> list[ChangelogEntry]:
+    """Parse Debian changelog text into newest-first structured entries."""
     entries: list[ChangelogEntry] = []
     current: dict[str, object] | None = None
     changes: list[str] = []
@@ -94,6 +100,7 @@ def parse_changelog(text: str) -> list[ChangelogEntry]:
 
 
 def load_entries(package: str | None, changelog: Path | None = None) -> list[ChangelogEntry]:
+    """Load changelog entries from an explicit file or package default path."""
     path = changelog or (default_changelog_path(package) if package else None)
     if not path:
         raise ValueError("Either package or changelog file must be specified")
@@ -104,6 +111,7 @@ def load_entries(package: str | None, changelog: Path | None = None) -> list[Cha
 
 
 def filter_entries(entries: Iterable[ChangelogEntry], query: str | None = None) -> list[ChangelogEntry]:
+    """Return entries whose version or change text contains the query."""
     entries = list(entries)
     if not query:
         return entries
@@ -112,6 +120,7 @@ def filter_entries(entries: Iterable[ChangelogEntry], query: str | None = None) 
 
 
 def compare_entries(entries: Iterable[ChangelogEntry], older: str, newer: str) -> list[ChangelogEntry]:
+    """Select the contiguous changelog range from newer down to older."""
     materialized = list(entries)
     versions = [entry.version for entry in materialized]
     if older not in versions or newer not in versions:
@@ -132,6 +141,7 @@ def compare_entries(entries: Iterable[ChangelogEntry], older: str, newer: str) -
 
 
 def format_entries(entries: Iterable[ChangelogEntry]) -> str:
+    """Render changelog entries as readable CLI output with security markers."""
     lines: list[str] = []
     for entry in entries:
         marker = "🔐 " if entry.has_security_fix else ""
@@ -144,6 +154,7 @@ def format_entries(entries: Iterable[ChangelogEntry]) -> str:
 
 
 def export_entries(entries: Iterable[ChangelogEntry], output: Path) -> None:
+    """Write entries to JSON, including computed security-fix metadata."""
     data = []
     for entry in entries:
         item = asdict(entry)
@@ -154,6 +165,7 @@ def export_entries(entries: Iterable[ChangelogEntry], output: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Create the changelog viewer command-line parser."""
     parser = argparse.ArgumentParser(description="View/search package changelogs")
     parser.add_argument("package", nargs="?", help="package directory name under packages/")
     parser.add_argument("older", nargs="?", help="older version for compare mode")
@@ -166,6 +178,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the changelog viewer CLI and return a process exit code."""
     args = build_parser().parse_args(argv)
     if not args.package and not args.file:
         build_parser().error("Either package or --file must be specified.")

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -20,8 +20,8 @@ CHANGELOG_HEADER = re.compile(
     r"^(?P<package>[\w.+-]+) \((?P<version>[^)]+)\) (?P<distribution>[^;]+); urgency=(?P<urgency>\S+)"
 )
 SECURITY_RE = re.compile(r"\b(CVE-\d{4}-\d{4,}|security|vulnerab|exploit|privilege|auth)\b", re.I)
-BULLET_RE = re.compile(r"^\s{2,}\*\s?(?P<text>.*)$")
-MAINTAINER_RE = re.compile(r"^ -- (?P<maintainer>.+?)  (?P<date>.+)$")
+BULLET_RE = re.compile(r"^\s{2,}[*-]\s?(?P<text>.*)$")
+MAINTAINER_RE = re.compile(r"^ -- (?P<maintainer>.+?)\s{2,}(?P<date>.+)$")
 
 
 @dataclass(frozen=True)
@@ -93,10 +93,13 @@ def parse_changelog(text: str) -> list[ChangelogEntry]:
     return entries
 
 
-def load_entries(package: str, changelog: Path | None = None) -> list[ChangelogEntry]:
-    path = changelog or default_changelog_path(package)
+def load_entries(package: str | None, changelog: Path | None = None) -> list[ChangelogEntry]:
+    path = changelog or (default_changelog_path(package) if package else None)
+    if not path:
+        raise ValueError("Either package or changelog file must be specified")
     if not path.exists():
-        raise FileNotFoundError(f"No changelog found for {package!r}: {path}")
+        msg = f"No changelog found for {package!r}: {path}" if package else f"No changelog found: {path}"
+        raise FileNotFoundError(msg)
     return parse_changelog(path.read_text(encoding="utf-8"))
 
 
@@ -109,15 +112,22 @@ def filter_entries(entries: Iterable[ChangelogEntry], query: str | None = None) 
 
 
 def compare_entries(entries: Iterable[ChangelogEntry], older: str, newer: str) -> list[ChangelogEntry]:
+    materialized = list(entries)
+    versions = [entry.version for entry in materialized]
+    if older not in versions or newer not in versions:
+        raise ValueError(f"compare bounds not found: older={older!r}, newer={newer!r}")
+
     selected: list[ChangelogEntry] = []
     capture = False
-    for entry in entries:
+    for entry in materialized:
         if entry.version == newer:
             capture = True
         if capture:
             selected.append(entry)
         if entry.version == older:
             break
+    if not selected or selected[-1].version != older:
+        raise ValueError(f"newer version {newer!r} must appear before older version {older!r}")
     return selected
 
 
@@ -139,12 +149,13 @@ def export_entries(entries: Iterable[ChangelogEntry], output: Path) -> None:
         item = asdict(entry)
         item["has_security_fix"] = entry.has_security_fix
         data.append(item)
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="View/search package changelogs")
-    parser.add_argument("package", help="package directory name under packages/")
+    parser.add_argument("package", nargs="?", help="package directory name under packages/")
     parser.add_argument("older", nargs="?", help="older version for compare mode")
     parser.add_argument("newer", nargs="?", help="newer version for compare mode")
     parser.add_argument("--file", type=Path, help="read a specific changelog file")
@@ -156,6 +167,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if not args.package and not args.file:
+        build_parser().error("Either package or --file must be specified.")
     try:
         entries = load_entries(args.package, args.file)
     except FileNotFoundError as exc:
@@ -166,14 +179,22 @@ def main(argv: list[str] | None = None) -> int:
         if not (args.older and args.newer):
             print("compare mode requires both older and newer versions", file=sys.stderr)
             return 2
-        entries = compare_entries(entries, args.older, args.newer)
+        try:
+            entries = compare_entries(entries, args.older, args.newer)
+        except ValueError as exc:
+            print(exc, file=sys.stderr)
+            return 2
 
     entries = filter_entries(entries, args.search)
     if args.security:
         entries = [entry for entry in entries if entry.has_security_fix]
 
     if args.export:
-        export_entries(entries, args.export)
+        try:
+            export_entries(entries, args.export)
+        except OSError as exc:
+            print(f"failed to export JSON: {exc}", file=sys.stderr)
+            return 2
 
     output = format_entries(entries)
     if output:

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -31,7 +31,10 @@ SAMPLE_CHANGELOG = textwrap.dedent(
 
 
 class ChangelogViewerTests(unittest.TestCase):
+    """Regression coverage for the offline Debian changelog viewer."""
+
     def test_parse_entries_and_security_detection(self):
+        """Parse release blocks and mark entries with security-related changes."""
         entries = changelog.parse_changelog(SAMPLE_CHANGELOG)
 
         self.assertEqual([entry.version for entry in entries], ["24.0.7-1", "24.0.6-1"])
@@ -40,6 +43,7 @@ class ChangelogViewerTests(unittest.TestCase):
         self.assertIn("Container restart issues", entries[0].changes[1])
 
     def test_parse_dash_bullets_and_extra_maintainer_spacing(self):
+        """Accept dash bullets and flexible spacing before maintainer dates."""
         text = textwrap.dedent(
             """
             curl (8.5.0-1) stable; urgency=medium
@@ -57,6 +61,7 @@ class ChangelogViewerTests(unittest.TestCase):
         self.assertEqual(entries[0].date, "Mon, 01 Jan 2024 10:00:00 +0000")
 
     def test_search_and_compare_versions(self):
+        """Filter by text and validate compare-mode version bounds."""
         entries = changelog.parse_changelog(SAMPLE_CHANGELOG)
 
         self.assertEqual([entry.version for entry in changelog.filter_entries(entries, "BuildKit")], ["24.0.7-1"])
@@ -69,6 +74,7 @@ class ChangelogViewerTests(unittest.TestCase):
             changelog.compare_entries(entries, "24.0.7-1", "24.0.6-1")
 
     def test_export_json_and_cli_output(self):
+        """Export filtered entries to JSON while keeping readable CLI output."""
         with tempfile.TemporaryDirectory() as tempdir:
             temp = Path(tempdir)
             source = temp / "changelog"
@@ -98,6 +104,7 @@ class ChangelogViewerTests(unittest.TestCase):
             self.assertTrue(exported[0]["has_security_fix"])
 
     def test_export_creates_parent_directories(self):
+        """Create missing parent directories for JSON export targets."""
         with tempfile.TemporaryDirectory() as tempdir:
             output = Path(tempdir) / "nested" / "out.json"
 
@@ -106,6 +113,7 @@ class ChangelogViewerTests(unittest.TestCase):
             self.assertTrue(output.exists())
 
     def test_cli_rejects_missing_or_invalid_compare_bounds(self):
+        """Return a controlled non-zero exit when compare bounds are invalid."""
         with tempfile.TemporaryDirectory() as tempdir:
             source = Path(tempdir) / "changelog"
             source.write_text(SAMPLE_CHANGELOG, encoding="utf-8")

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import changelog  # noqa: E402
+
+SAMPLE_CHANGELOG = textwrap.dedent(
+    """
+    docker (24.0.7-1) stable; urgency=medium
+
+      * Security: CVE-2023-12345 fixed in container runtime.
+      * Bug fixes: Container restart issues.
+      * New: BuildKit 0.12 support.
+
+     -- CX Maintainer <dev@example.com>  Wed, 15 Nov 2023 10:00:00 +0000
+
+    docker (24.0.6-1) stable; urgency=low
+
+      * Bug fixes: Improve image pull retries.
+
+     -- CX Maintainer <dev@example.com>  Fri, 20 Oct 2023 10:00:00 +0000
+    """
+).strip()
+
+
+class ChangelogViewerTests(unittest.TestCase):
+    def test_parse_entries_and_security_detection(self):
+        entries = changelog.parse_changelog(SAMPLE_CHANGELOG)
+
+        self.assertEqual([entry.version for entry in entries], ["24.0.7-1", "24.0.6-1"])
+        self.assertTrue(entries[0].has_security_fix)
+        self.assertFalse(entries[1].has_security_fix)
+        self.assertIn("Container restart issues", entries[0].changes[1])
+
+    def test_search_and_compare_versions(self):
+        entries = changelog.parse_changelog(SAMPLE_CHANGELOG)
+
+        self.assertEqual([entry.version for entry in changelog.filter_entries(entries, "BuildKit")], ["24.0.7-1"])
+        compared = changelog.compare_entries(entries, "24.0.6-1", "24.0.7-1")
+        self.assertEqual([entry.version for entry in compared], ["24.0.7-1", "24.0.6-1"])
+
+    def test_export_json_and_cli_output(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp = Path(tempdir)
+            source = temp / "changelog"
+            output = temp / "out.json"
+            source.write_text(SAMPLE_CHANGELOG, encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "changelog.py"),
+                    "docker",
+                    "--file",
+                    str(source),
+                    "--security",
+                    "--export",
+                    str(output),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertIn("CVE-2023-12345", result.stdout)
+            exported = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(len(exported), 1)
+            self.assertTrue(exported[0]["has_security_fix"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -75,7 +75,9 @@ class ChangelogViewerTests(unittest.TestCase):
             output = temp / "out.json"
             source.write_text(SAMPLE_CHANGELOG, encoding="utf-8")
 
-            result = subprocess.run(
+            # Safe in this test: invoke the local helper with a fixed Python executable
+            # and argument list, never a shell-interpreted command string.
+            result = subprocess.run(  # noqa: S603
                 [
                     sys.executable,
                     str(ROOT / "scripts" / "changelog.py"),
@@ -108,7 +110,9 @@ class ChangelogViewerTests(unittest.TestCase):
             source = Path(tempdir) / "changelog"
             source.write_text(SAMPLE_CHANGELOG, encoding="utf-8")
 
-            result = subprocess.run(
+            # Safe in this test: invoke the local helper with a fixed Python executable
+            # and argument list, never a shell-interpreted command string.
+            result = subprocess.run(  # noqa: S603
                 [
                     sys.executable,
                     str(ROOT / "scripts" / "changelog.py"),

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -39,12 +39,34 @@ class ChangelogViewerTests(unittest.TestCase):
         self.assertFalse(entries[1].has_security_fix)
         self.assertIn("Container restart issues", entries[0].changes[1])
 
+    def test_parse_dash_bullets_and_extra_maintainer_spacing(self):
+        text = textwrap.dedent(
+            """
+            curl (8.5.0-1) stable; urgency=medium
+
+              - Fix HTTP retry handling.
+
+             -- CX Maintainer <dev@example.com>    Mon, 01 Jan 2024 10:00:00 +0000
+            """
+        ).strip()
+
+        entries = changelog.parse_changelog(text)
+
+        self.assertEqual(entries[0].changes, ("Fix HTTP retry handling.",))
+        self.assertEqual(entries[0].maintainer, "CX Maintainer <dev@example.com>")
+        self.assertEqual(entries[0].date, "Mon, 01 Jan 2024 10:00:00 +0000")
+
     def test_search_and_compare_versions(self):
         entries = changelog.parse_changelog(SAMPLE_CHANGELOG)
 
         self.assertEqual([entry.version for entry in changelog.filter_entries(entries, "BuildKit")], ["24.0.7-1"])
         compared = changelog.compare_entries(entries, "24.0.6-1", "24.0.7-1")
         self.assertEqual([entry.version for entry in compared], ["24.0.7-1", "24.0.6-1"])
+
+        with self.assertRaises(ValueError):
+            changelog.compare_entries(entries, "24.0.5-1", "24.0.7-1")
+        with self.assertRaises(ValueError):
+            changelog.compare_entries(entries, "24.0.7-1", "24.0.6-1")
 
     def test_export_json_and_cli_output(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -57,7 +79,6 @@ class ChangelogViewerTests(unittest.TestCase):
                 [
                     sys.executable,
                     str(ROOT / "scripts" / "changelog.py"),
-                    "docker",
                     "--file",
                     str(source),
                     "--security",
@@ -73,6 +94,37 @@ class ChangelogViewerTests(unittest.TestCase):
             exported = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(len(exported), 1)
             self.assertTrue(exported[0]["has_security_fix"])
+
+    def test_export_creates_parent_directories(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            output = Path(tempdir) / "nested" / "out.json"
+
+            changelog.export_entries(changelog.parse_changelog(SAMPLE_CHANGELOG), output)
+
+            self.assertTrue(output.exists())
+
+    def test_cli_rejects_missing_or_invalid_compare_bounds(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            source = Path(tempdir) / "changelog"
+            source.write_text(SAMPLE_CHANGELOG, encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "changelog.py"),
+                    "docker",
+                    "24.0.5-1",
+                    "24.0.7-1",
+                    "--file",
+                    str(source),
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("compare bounds not found", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds an offline package changelog viewer at `scripts/changelog.py` for local Debian package changelogs under `packages/<name>/debian/changelog`
- Supports formatted display, text/version search, security-fix filtering, version-range comparison, and JSON export
- Adds focused unit tests plus a `make test-changelog` target and README usage examples

## Test plan
- `python3 -m py_compile scripts/changelog.py tests/test_changelog.py`
- `python3 -m unittest tests/test_changelog.py`
- `make test-changelog`
- `python3 scripts/changelog.py cx-core --security --export /tmp/cx-core-security.json`
- `git diff --check`

Refs #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline changelog viewer: inspect Debian package changelogs with search, filtering, version comparison, and JSON export.
  * Optional security-only filtering/highlighting for entries and bullets.

* **Chores**
  * Added public make target `test-changelog` and documented it in help/.PHONY.
  * Updated `test` target to run changelog unit tests.

* **Documentation**
  * README updated with usage and build-target docs for the changelog viewer.

* **Tests**
  * Added unit/integration tests covering parsing, security detection, search/compare, export, and CLI error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->