### PR TITLE
Add package profile management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ Everything in cx-core plus:
 - GPU support prerequisites
 - Modern CLI tools (htop, btop, fzf, ripgrep, bat)
 
+### Named Package Profiles
+
+CX can save named package installation profiles for repeatable environment
+switching:
+
+```bash
+cortex profile create development --package nodejs --package python3 --package docker.io
+cortex profile copy development production
+cortex profile edit production --remove nodejs --add nginx --add certbot
+cortex profile diff development production
+cortex profile switch production
+```
+
+Profiles support creation, validation, active-profile switching, version history,
+and JSON import/export for sharing. See
+[docs/profile-management.md](docs/profile-management.md) for the full command
+reference and examples.
+
 ## Automated Installation
 
 CX Linux supports fully unattended installation via preseed:

--- a/docs/profile-management.md
+++ b/docs/profile-management.md
@@ -1,0 +1,92 @@
+# Package Installation Profiles
+
+CX profiles save named package sets so a host can switch between repeatable
+installation targets such as `development`, `production`, or `gpu-workstation`.
+
+Profiles are stored as JSON. By default the CLI writes to
+`~/.config/cx/profiles.json`. Set `CX_PROFILE_STATE` to point at a different
+state file for tests, automation, or system-wide provisioning.
+
+## Commands
+
+Create a profile:
+
+```bash
+cortex profile create development --package nodejs --package python3 --package docker.io
+```
+
+Show the active profile:
+
+```bash
+cortex profile active
+```
+
+Copy and edit a profile:
+
+```bash
+cortex profile copy development production
+cortex profile edit production --remove nodejs --add nginx --add certbot
+```
+
+Validate before switching:
+
+```bash
+cortex profile validate production
+```
+
+Switch profiles:
+
+```bash
+cortex profile switch production
+```
+
+The switch command validates the destination and prints the package delta:
+
+```text
+development -> production:
+  - nodejs
+  + certbot
+  + nginx
+```
+
+Compare profiles without switching:
+
+```bash
+cortex profile diff development production
+```
+
+Export and import profiles for sharing:
+
+```bash
+cortex profile export production production.cx-profile.json
+cortex profile import production.cx-profile.json --name staging
+```
+
+Inspect version history:
+
+```bash
+cortex profile history production
+```
+
+Each create, copy, import, and edit operation appends a version snapshot with the
+package list at that point in time. These snapshots make profile changes auditable
+and provide a base for future rollback commands.
+
+## Example Workflow
+
+```bash
+cortex profile create development -p nodejs -p python3 -p docker.io
+cortex profile copy development production
+cortex profile edit production --remove nodejs --add nginx --add certbot
+cortex profile diff development production
+cortex profile switch production
+cortex profile export production ./production.cx-profile.json
+```
+
+## Validation Rules
+
+- Profile names must be 1-64 characters.
+- Profile names may contain letters, numbers, dot, underscore, and dash.
+- Package names may contain letters, numbers, plus, dot, underscore, colon, and dash.
+- Duplicate package names are removed automatically.
+- Import files must use the `cx-profile` export format.

--- a/docs/profile-management.md
+++ b/docs/profile-management.md
@@ -87,6 +87,8 @@ cortex profile export production ./production.cx-profile.json
 
 - Profile names must be 1-64 characters.
 - Profile names may contain letters, numbers, dot, underscore, and dash.
-- Package names may contain letters, numbers, plus, dot, underscore, colon, and dash.
+- Package names must be 1-128 characters.
+- Package names must start with a letter or number.
+- Package names may then contain letters, numbers, plus, dot, underscore, colon, and dash.
 - Duplicate package names are removed automatically.
 - Import files must use the `cx-profile` export format.

--- a/packages/cx-core/debian/rules
+++ b/packages/cx-core/debian/rules
@@ -36,5 +36,13 @@ override_dh_auto_install:
 	echo 'python3 -m cx.cli "$$@"' >> $(CURDIR)/debian/cx-core/usr/bin/cx
 	chmod 755 $(CURDIR)/debian/cx-core/usr/bin/cx
 
+	# Install local profile manager and command dispatchers.
+	install -m 755 ../../src/cx_profile.py \
+		$(CURDIR)/debian/cx-core/usr/share/cx/cx_profile.py
+	install -m 755 ../../src/cortex \
+		$(CURDIR)/debian/cx-core/usr/bin/cortex
+	ln -sf /usr/share/cx/cx_profile.py \
+		$(CURDIR)/debian/cx-core/usr/bin/cx-profile
+
 override_dh_auto_clean:
 	@echo "No clean step required"

--- a/src/cortex
+++ b/src/cortex
@@ -1,0 +1,35 @@
+#!/bin/bash
+# CX Linux command dispatcher.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROFILE_CLI="$SCRIPT_DIR/cx_profile.py"
+if [[ ! -f "$PROFILE_CLI" && -f /usr/share/cx/cx_profile.py ]]; then
+  PROFILE_CLI="/usr/share/cx/cx_profile.py"
+fi
+
+case "${1:-}" in
+  profile)
+    shift
+    exec python3 "$PROFILE_CLI" "$@"
+    ;;
+  ""|-h|--help|help)
+    cat <<'EOF'
+Usage: cortex <command> [args]
+
+Commands:
+  profile    Manage package installation profiles
+
+Examples:
+  cortex profile create development --package nodejs --package python3
+  cortex profile active
+  cortex profile switch production
+EOF
+    ;;
+  *)
+    echo "Unknown cortex command: $1" >&2
+    echo "Run 'cortex --help' for usage." >&2
+    exit 2
+    ;;
+esac

--- a/src/cx_profile.py
+++ b/src/cx_profile.py
@@ -76,7 +76,7 @@ def validate_profile_name(name: str) -> None:
 
 class ProfileStore:
     def __init__(self, path: Path | None = None) -> None:
-        self.path = path or default_state_path()
+        self.path = (path or default_state_path()).expanduser()
         self.state = self._load()
 
     def _load(self) -> dict[str, Any]:
@@ -98,12 +98,13 @@ class ProfileStore:
         return state
 
     def save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        target = self.path.resolve() if self.path.exists() else self.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
         with tmp.open("w", encoding="utf-8") as handle:
             json.dump(self.state, handle, indent=2, sort_keys=True)
             handle.write("\n")
-        tmp.replace(self.path)
+        tmp.replace(target)
 
     @property
     def profiles(self) -> dict[str, Any]:
@@ -212,7 +213,12 @@ class ProfileStore:
         validate_profile_name(imported_name)
         if imported_name in self.profiles:
             raise ProfileError(f"Profile already exists: {imported_name}")
-        packages = normalize_packages([str(package) for package in profile.get("packages", [])])
+        raw_packages = profile.get("packages", [])
+        if not isinstance(raw_packages, list):
+            raise ProfileError("Imported profile 'packages' must be a list")
+        if not all(isinstance(package, str) for package in raw_packages):
+            raise ProfileError("All packages in the imported profile must be strings")
+        packages = normalize_packages(raw_packages)
         created = {
             "name": imported_name,
             "packages": packages,
@@ -307,9 +313,9 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    store = ProfileStore()
 
     try:
+        store = ProfileStore()
         if args.command == "create":
             profile = store.create(args.name, args.package)
             print(f"Profile '{profile['name']}' created")

--- a/src/cx_profile.py
+++ b/src/cx_profile.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""CX package installation profile manager.
+
+The tool intentionally uses only the Python standard library so it can run on
+fresh CX Linux systems before optional Python packages are installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+PACKAGE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9+_.:-]{0,127}$")
+STATE_VERSION = 1
+
+
+class ProfileError(RuntimeError):
+    """User-facing profile command error."""
+
+
+@dataclass(frozen=True)
+class Diff:
+    added: list[str]
+    removed: list[str]
+    unchanged: list[str]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def default_state_path() -> Path:
+    if os.environ.get("CX_PROFILE_STATE"):
+        return Path(os.environ["CX_PROFILE_STATE"]).expanduser()
+    if os.environ.get("CX_PROFILE_DIR"):
+        return Path(os.environ["CX_PROFILE_DIR"]).expanduser() / "profiles.json"
+    return Path.home() / ".config" / "cx" / "profiles.json"
+
+
+def empty_state() -> dict[str, Any]:
+    return {"version": STATE_VERSION, "active": None, "profiles": {}}
+
+
+def normalize_packages(packages: list[str] | None) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for raw in packages or []:
+        package = raw.strip()
+        if not package:
+            continue
+        if not PACKAGE_NAME_RE.match(package):
+            raise ProfileError(f"Invalid package name: {raw!r}")
+        if package not in seen:
+            normalized.append(package)
+            seen.add(package)
+    return sorted(normalized)
+
+
+def validate_profile_name(name: str) -> None:
+    if not PROFILE_NAME_RE.match(name):
+        raise ProfileError(
+            "Profile names must be 1-64 characters and may contain only "
+            "letters, numbers, dot, underscore, and dash."
+        )
+
+
+class ProfileStore:
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or default_state_path()
+        self.state = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return empty_state()
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                state = json.load(handle)
+        except json.JSONDecodeError as exc:
+            raise ProfileError(f"Invalid profile state JSON: {self.path}") from exc
+
+        if not isinstance(state, dict):
+            raise ProfileError("Profile state must be a JSON object")
+        state.setdefault("version", STATE_VERSION)
+        state.setdefault("active", None)
+        state.setdefault("profiles", {})
+        if not isinstance(state["profiles"], dict):
+            raise ProfileError("Profile state 'profiles' must be a JSON object")
+        return state
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as handle:
+            json.dump(self.state, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        tmp.replace(self.path)
+
+    @property
+    def profiles(self) -> dict[str, Any]:
+        return self.state["profiles"]
+
+    def require_profile(self, name: str) -> dict[str, Any]:
+        try:
+            return self.profiles[name]
+        except KeyError as exc:
+            raise ProfileError(f"Profile does not exist: {name}") from exc
+
+    def create(self, name: str, packages: list[str] | None = None) -> dict[str, Any]:
+        validate_profile_name(name)
+        if name in self.profiles:
+            raise ProfileError(f"Profile already exists: {name}")
+        profile = {
+            "name": name,
+            "packages": normalize_packages(packages),
+            "created_at": utc_now(),
+            "updated_at": utc_now(),
+            "versions": [],
+        }
+        self.profiles[name] = profile
+        self._record_version(name, "create")
+        if self.state["active"] is None:
+            self.state["active"] = name
+        self.save()
+        return profile
+
+    def copy(self, source: str, destination: str) -> dict[str, Any]:
+        source_profile = self.require_profile(source)
+        validate_profile_name(destination)
+        if destination in self.profiles:
+            raise ProfileError(f"Profile already exists: {destination}")
+        profile = deepcopy(source_profile)
+        profile["name"] = destination
+        profile["created_at"] = utc_now()
+        profile["updated_at"] = utc_now()
+        profile["versions"] = []
+        self.profiles[destination] = profile
+        self._record_version(destination, f"copy from {source}")
+        self.save()
+        return profile
+
+    def edit(self, name: str, add: list[str] | None, remove: list[str] | None) -> dict[str, Any]:
+        profile = self.require_profile(name)
+        packages = set(profile.get("packages", []))
+        packages.update(normalize_packages(add))
+        for package in normalize_packages(remove):
+            packages.discard(package)
+        profile["packages"] = sorted(packages)
+        profile["updated_at"] = utc_now()
+        self._record_version(name, "edit")
+        self.save()
+        return profile
+
+    def switch(self, name: str) -> Diff:
+        self.validate(name)
+        previous = self.state.get("active")
+        diff = self.diff(previous, name) if previous else Diff(
+            added=self.require_profile(name)["packages"],
+            removed=[],
+            unchanged=[],
+        )
+        self.state["active"] = name
+        self.save()
+        return diff
+
+    def validate(self, name: str) -> None:
+        profile = self.require_profile(name)
+        validate_profile_name(name)
+        packages = profile.get("packages")
+        if not isinstance(packages, list):
+            raise ProfileError(f"Profile {name} has invalid packages list")
+        normalize_packages([str(package) for package in packages])
+
+    def diff(self, left: str | None, right: str) -> Diff:
+        if left is None:
+            left_packages: set[str] = set()
+        else:
+            left_packages = set(self.require_profile(left).get("packages", []))
+        right_packages = set(self.require_profile(right).get("packages", []))
+        return Diff(
+            added=sorted(right_packages - left_packages),
+            removed=sorted(left_packages - right_packages),
+            unchanged=sorted(left_packages & right_packages),
+        )
+
+    def export_profile(self, name: str) -> dict[str, Any]:
+        self.validate(name)
+        profile = deepcopy(self.require_profile(name))
+        return {
+            "format": "cx-profile",
+            "format_version": STATE_VERSION,
+            "exported_at": utc_now(),
+            "profile": profile,
+        }
+
+    def import_profile(self, payload: dict[str, Any], name: str | None = None) -> dict[str, Any]:
+        if payload.get("format") != "cx-profile":
+            raise ProfileError("Import file is not a cx-profile export")
+        profile = payload.get("profile")
+        if not isinstance(profile, dict):
+            raise ProfileError("Import file does not contain a profile object")
+        imported_name = name or str(profile.get("name", ""))
+        validate_profile_name(imported_name)
+        if imported_name in self.profiles:
+            raise ProfileError(f"Profile already exists: {imported_name}")
+        packages = normalize_packages([str(package) for package in profile.get("packages", [])])
+        created = {
+            "name": imported_name,
+            "packages": packages,
+            "created_at": utc_now(),
+            "updated_at": utc_now(),
+            "versions": [],
+        }
+        self.profiles[imported_name] = created
+        self._record_version(imported_name, "import")
+        if self.state["active"] is None:
+            self.state["active"] = imported_name
+        self.save()
+        return created
+
+    def _record_version(self, name: str, message: str) -> None:
+        profile = self.require_profile(name)
+        versions = profile.setdefault("versions", [])
+        versions.append(
+            {
+                "id": len(versions) + 1,
+                "created_at": utc_now(),
+                "message": message,
+                "packages": list(profile.get("packages", [])),
+            }
+        )
+        profile["updated_at"] = utc_now()
+
+
+def print_profile(profile: dict[str, Any], active: bool = False) -> None:
+    marker = "*" if active else " "
+    packages = profile.get("packages", [])
+    print(f"{marker} {profile['name']} ({len(packages)} packages)")
+    if packages:
+        print("  - " + ", ".join(packages))
+
+
+def print_diff(diff: Diff, left: str | None, right: str) -> None:
+    source = left or "<empty>"
+    print(f"{source} -> {right}:")
+    for package in diff.removed:
+        print(f"  - {package}")
+    for package in diff.added:
+        print(f"  + {package}")
+    if not diff.added and not diff.removed:
+        print("  no package changes")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cx-profile", description="Manage CX package installation profiles")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create", help="create a named profile")
+    create.add_argument("name")
+    create.add_argument("--package", "-p", action="append", default=[], help="package to include")
+
+    sub.add_parser("list", help="list profiles")
+    sub.add_parser("active", help="show the active profile")
+
+    copy = sub.add_parser("copy", help="copy a profile")
+    copy.add_argument("source")
+    copy.add_argument("destination")
+
+    edit = sub.add_parser("edit", help="add or remove packages")
+    edit.add_argument("name")
+    edit.add_argument("--add", action="append", default=[])
+    edit.add_argument("--remove", action="append", default=[])
+
+    switch = sub.add_parser("switch", help="validate and activate a profile")
+    switch.add_argument("name")
+
+    diff = sub.add_parser("diff", help="show package differences between profiles")
+    diff.add_argument("left")
+    diff.add_argument("right")
+
+    validate = sub.add_parser("validate", help="validate a profile")
+    validate.add_argument("name")
+
+    export = sub.add_parser("export", help="export a profile to JSON")
+    export.add_argument("name")
+    export.add_argument("path", nargs="?", help="output path; stdout when omitted")
+
+    import_cmd = sub.add_parser("import", help="import a profile JSON export")
+    import_cmd.add_argument("path")
+    import_cmd.add_argument("--name", help="override imported profile name")
+
+    history = sub.add_parser("history", help="show profile version history")
+    history.add_argument("name")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    store = ProfileStore()
+
+    try:
+        if args.command == "create":
+            profile = store.create(args.name, args.package)
+            print(f"Profile '{profile['name']}' created")
+            return 0
+        if args.command == "list":
+            active = store.state.get("active")
+            for name in sorted(store.profiles):
+                print_profile(store.profiles[name], active=name == active)
+            return 0
+        if args.command == "active":
+            active = store.state.get("active")
+            if not active:
+                print("No active profile")
+                return 1
+            print("Current:", active)
+            print_profile(store.require_profile(active), active=True)
+            return 0
+        if args.command == "copy":
+            profile = store.copy(args.source, args.destination)
+            print(f"Profile '{profile['name']}' copied from '{args.source}'")
+            return 0
+        if args.command == "edit":
+            profile = store.edit(args.name, args.add, args.remove)
+            print(f"Profile '{profile['name']}' updated")
+            return 0
+        if args.command == "switch":
+            previous = store.state.get("active")
+            diff = store.switch(args.name)
+            print(f"Switched to '{args.name}' profile")
+            print_diff(diff, previous, args.name)
+            return 0
+        if args.command == "diff":
+            print_diff(store.diff(args.left, args.right), args.left, args.right)
+            return 0
+        if args.command == "validate":
+            store.validate(args.name)
+            print(f"Profile '{args.name}' is valid")
+            return 0
+        if args.command == "export":
+            payload = store.export_profile(args.name)
+            output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.path:
+                Path(args.path).write_text(output, encoding="utf-8")
+                print(f"Profile '{args.name}' exported to {args.path}")
+            else:
+                print(output, end="")
+            return 0
+        if args.command == "import":
+            payload = json.loads(Path(args.path).read_text(encoding="utf-8"))
+            profile = store.import_profile(payload, args.name)
+            print(f"Profile '{profile['name']}' imported")
+            return 0
+        if args.command == "history":
+            profile = store.require_profile(args.name)
+            for version in profile.get("versions", []):
+                print(
+                    f"v{version['id']} {version['created_at']} "
+                    f"{version['message']} ({len(version['packages'])} packages)"
+                )
+            return 0
+    except (OSError, json.JSONDecodeError, ProfileError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    parser.error(f"Unhandled command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cx_profile.py
+++ b/tests/test_cx_profile.py
@@ -92,6 +92,26 @@ class ProfileCliTests(unittest.TestCase):
         data = json.loads((isolated / "profiles.json").read_text())
         self.assertEqual(data["profiles"]["imported-dev"]["packages"], ["python3"])
 
+    def test_import_rejects_invalid_package_payload(self):
+        export_path = self.tmp_path / "bad.cx-profile.json"
+        export_path.write_text(
+            json.dumps({"format": "cx-profile", "profile": {"name": "bad", "packages": [123]}}),
+            encoding="utf-8",
+        )
+
+        result = self.run_profile("import", str(export_path))
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("must be strings", result.stderr)
+
+    def test_invalid_state_reports_clean_error(self):
+        state_path = self.tmp_path / "profiles.json"
+        state_path.write_text("{not-json", encoding="utf-8")
+
+        result = self.run_profile("list")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Invalid profile state JSON", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
     def test_validation_rejects_bad_profile_and_package_names(self):
         bad_profile = self.run_profile("create", "bad/name")
         self.assertEqual(bad_profile.returncode, 2)

--- a/tests/test_cx_profile.py
+++ b/tests/test_cx_profile.py
@@ -1,0 +1,106 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "src" / "cx_profile.py"
+
+
+class ProfileCliTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_profile(self, *args, state_dir=None):
+        state_dir = state_dir or self.tmp_path
+        env = os.environ.copy()
+        env["CX_PROFILE_STATE"] = str(state_dir / "profiles.json")
+        return subprocess.run(
+            [sys.executable, str(CLI), *args],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_create_active_edit_and_history(self):
+        result = self.run_profile("create", "development", "--package", "python3", "--package", "nodejs")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("created", result.stdout)
+
+        active = self.run_profile("active")
+        self.assertEqual(active.returncode, 0)
+        self.assertIn("Current: development", active.stdout)
+        self.assertIn("nodejs", active.stdout)
+        self.assertIn("python3", active.stdout)
+
+        edited = self.run_profile("edit", "development", "--add", "docker.io", "--remove", "nodejs")
+        self.assertEqual(edited.returncode, 0)
+
+        history = self.run_profile("history", "development")
+        self.assertEqual(history.returncode, 0)
+        self.assertIn("create", history.stdout)
+        self.assertIn("edit", history.stdout)
+
+        data = json.loads((self.tmp_path / "profiles.json").read_text())
+        self.assertEqual(data["active"], "development")
+        self.assertEqual(data["profiles"]["development"]["packages"], ["docker.io", "python3"])
+        self.assertEqual(len(data["profiles"]["development"]["versions"]), 2)
+
+    def test_copy_switch_diff_and_validate(self):
+        self.assertEqual(self.run_profile("create", "development", "-p", "nodejs", "-p", "python3").returncode, 0)
+        self.assertEqual(self.run_profile("copy", "development", "production").returncode, 0)
+        self.assertEqual(self.run_profile("edit", "production", "--remove", "nodejs", "--add", "nginx").returncode, 0)
+
+        diff = self.run_profile("diff", "development", "production")
+        self.assertEqual(diff.returncode, 0)
+        self.assertIn("- nodejs", diff.stdout)
+        self.assertIn("+ nginx", diff.stdout)
+
+        switched = self.run_profile("switch", "production")
+        self.assertEqual(switched.returncode, 0)
+        self.assertIn("Switched to 'production'", switched.stdout)
+        self.assertIn("- nodejs", switched.stdout)
+        self.assertIn("+ nginx", switched.stdout)
+
+        valid = self.run_profile("validate", "production")
+        self.assertEqual(valid.returncode, 0)
+        self.assertIn("is valid", valid.stdout)
+
+    def test_export_import_profile(self):
+        self.assertEqual(self.run_profile("create", "development", "-p", "python3").returncode, 0)
+        export_path = self.tmp_path / "development.cx-profile.json"
+
+        exported = self.run_profile("export", "development", str(export_path))
+        self.assertEqual(exported.returncode, 0)
+        payload = json.loads(export_path.read_text())
+        self.assertEqual(payload["format"], "cx-profile")
+        self.assertEqual(payload["profile"]["packages"], ["python3"])
+
+        isolated = self.tmp_path / "imported"
+        isolated.mkdir()
+        imported = self.run_profile("import", str(export_path), "--name", "imported-dev", state_dir=isolated)
+        self.assertEqual(imported.returncode, 0, imported.stderr)
+        data = json.loads((isolated / "profiles.json").read_text())
+        self.assertEqual(data["profiles"]["imported-dev"]["packages"], ["python3"])
+
+    def test_validation_rejects_bad_profile_and_package_names(self):
+        bad_profile = self.run_profile("create", "bad/name")
+        self.assertEqual(bad_profile.returncode, 2)
+        self.assertIn("Profile names", bad_profile.stderr)
+
+        bad_package = self.run_profile("create", "development", "-p", "../bad")
+        self.assertEqual(bad_package.returncode, 2)
+        self.assertIn("Invalid package name", bad_package.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements package installation profiles for #28.

- Adds a standard-library Python profile manager with create/list/active/copy/edit/switch/diff/validate/export/import/history commands.
- Adds a `cortex profile ...` dispatcher plus `cx-profile` Debian package entrypoint.
- Stores version snapshots for create/copy/import/edit operations.
- Adds import/export JSON format for sharing profiles.
- Documents profile workflows and examples in `docs/profile-management.md` and links it from README.
- Adds standard-library unit tests covering profile creation, switching, diffing, validation, version history, and import/export.

Public contact for bounty follow-up: 9904099@gmail.com

Closes #28

## Validation

- `python3 -m py_compile src/cx_profile.py tests/test_cx_profile.py`
- `bash -n src/cortex packages/cx-core/debian/rules`
- `python3 -m unittest tests/test_cx_profile.py -v`
- Manual smoke:
  - `CX_PROFILE_STATE=$tmp/profiles.json ./src/cortex profile create development -p nodejs -p python3`
  - `CX_PROFILE_STATE=$tmp/profiles.json ./src/cortex profile copy development production`
  - `CX_PROFILE_STATE=$tmp/profiles.json ./src/cortex profile edit production --remove nodejs --add nginx`
  - `CX_PROFILE_STATE=$tmp/profiles.json ./src/cortex profile diff development production`

Note: `make package PKG=cx-core` was attempted, but this local container is missing the repository build dependency `debhelper-compat (= 13)`, so Debian package assembly could not complete here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named package installation profiles for creating and managing repeatable package sets
  * Profile management includes copying, editing, switching between profiles, and viewing version history

* **Documentation**
  * Added comprehensive guides for managing installation profiles and available CLI commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->