### PR TITLE
Add package dependency tree optimizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SHELL := /bin/bash
-.PHONY: all iso iso-netinst iso-offline package sbom clean test help
+.PHONY: all iso iso-netinst iso-offline package sbom clean test test-dep-tree-optimizer help
 
 # Build configuration
 CODENAME := trixie
@@ -37,6 +37,7 @@ help:
 	@echo "  package PKG=x Build specific package (cx-core, cx-full, cx-archive-keyring)"
 	@echo "  sbom          Generate Software Bill of Materials"
 	@echo "  test          Run build verification tests"
+	@echo "  test-dep-tree-optimizer Run dependency tree optimizer tests"
 	@echo "  clean         Remove build artifacts"
 	@echo "  deps          Install build dependencies"
 	@echo ""
@@ -161,6 +162,10 @@ test:
 	./tests/verify-packages.sh || true
 	./tests/verify-preseed.sh || true
 	@echo -e "$(GREEN)Tests complete$(NC)"
+
+test-dep-tree-optimizer:
+	@echo -e "$(GREEN)Running dependency tree optimizer tests...$(NC)"
+	./tests/optimize-dependency-tree-test.sh
 
 # Clean build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,38 @@ CX_GPG_KEY_ID=ABCD1234 ./repository/scripts/repo-manage.sh publish
 ./repository/scripts/repo-manage.sh export cx-offline-repo
 ```
 
+### Dependency tree optimizer
+
+Use the read-only dependency tree optimizer to inspect the smallest package
+closure for one or more packages before publishing repository metadata. The
+tool reads local `Packages` or `Packages.gz` indexes only; it does not call
+`apt`, `dpkg`, `sudo`, or the network.
+
+```bash
+# Use indexes discovered under ./dists
+apt/scripts/optimize-dependency-tree.py cx-full
+
+# Or pass one or more explicit package indexes
+apt/scripts/optimize-dependency-tree.py \
+  --index dists/trixie/main/binary-amd64/Packages.gz \
+  cx-core cx-full
+
+# Include Graphviz DOT output for visualization
+apt/scripts/optimize-dependency-tree.py --dot cx-full > dependency-plan.txt
+```
+
+The report includes selected packages, total `Installed-Size`, the dependency
+tree, missing dependency diagnostics, and conflict diagnostics. The command
+exits with status `0` for a complete non-conflicting plan, `1` when missing
+dependencies or conflicts are detected, and `2` when indexes cannot be read or
+no package index is available.
+
+Run the focused regression suite with:
+
+```bash
+make test-dep-tree-optimizer
+```
+
 ## Security
 
 ### Supply Chain

--- a/apt/scripts/optimize-dependency-tree.py
+++ b/apt/scripts/optimize-dependency-tree.py
@@ -19,8 +19,20 @@ from pathlib import Path
 
 DEP_SPLIT_RE = re.compile(r"\s*,\s*")
 ALT_SPLIT_RE = re.compile(r"\s*\|\s*")
-VERSION_RE = re.compile(r"\s*\([^)]*\)")
+RELATION_RE = re.compile(
+    r"^\s*([a-z0-9+.-]+(?::(?:any|native|[a-z0-9-]+))?)"
+    r"(?:\s*\((<<|<=|=|>=|>>)\s*([^)]+)\))?\s*$"
+)
 ARCH_RE = re.compile(r":(?:any|native|[a-z0-9-]+)$")
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """Package or virtual-package relationship requested by an APT field."""
+
+    name: str
+    operator: str = ""
+    version: str = ""
 
 
 @dataclass(frozen=True)
@@ -30,9 +42,9 @@ class Package:
     name: str
     version: str
     installed_size: int
-    depends: tuple[tuple[str, ...], ...]
-    conflicts: frozenset[str]
-    provides: frozenset[str]
+    depends: tuple[tuple[Requirement, ...], ...]
+    conflicts: frozenset[Requirement]
+    provides: frozenset[Requirement]
     description: str
 
 
@@ -53,35 +65,45 @@ class Resolution:
 
 
 def normalize_package_name(value: str) -> str:
-    """Strip version constraints and architecture qualifiers from a dependency token."""
-    value = VERSION_RE.sub("", value).strip()
-    value = ARCH_RE.sub("", value)
-    return value.strip()
+    """Strip architecture qualifiers from a package or virtual package name."""
+    return ARCH_RE.sub("", value).strip()
 
 
-def parse_dependency_groups(value: str) -> tuple[tuple[str, ...], ...]:
+def parse_requirement(value: str) -> Requirement | None:
+    """Parse a Debian package relationship token into name, operator, and version."""
+    match = RELATION_RE.match(value)
+    if not match:
+        name = normalize_package_name(value)
+        return Requirement(name) if name else None
+    name, operator, version = match.groups()
+    return Requirement(normalize_package_name(name), operator or "", version or "")
+
+
+def parse_dependency_groups(value: str) -> tuple[tuple[Requirement, ...], ...]:
     """Parse Depends/Pre-Depends text into comma groups with pipe alternatives."""
-    groups: list[tuple[str, ...]] = []
+    groups: list[tuple[Requirement, ...]] = []
     for group in DEP_SPLIT_RE.split(value):
         alternatives = tuple(
-            name
-            for name in (normalize_package_name(item) for item in ALT_SPLIT_RE.split(group))
-            if name
+            requirement
+            for requirement in (
+                parse_requirement(item) for item in ALT_SPLIT_RE.split(group)
+            )
+            if requirement
         )
         if alternatives:
             groups.append(alternatives)
     return tuple(groups)
 
 
-def parse_name_set(value: str) -> frozenset[str]:
+def parse_requirement_set(value: str) -> frozenset[Requirement]:
     """Parse a comma/pipe separated relationship field into normalized names."""
-    names: set[str] = set()
+    requirements: set[Requirement] = set()
     for group in DEP_SPLIT_RE.split(value):
         for item in ALT_SPLIT_RE.split(group):
-            name = normalize_package_name(item)
-            if name:
-                names.add(name)
-    return frozenset(names)
+            requirement = parse_requirement(item)
+            if requirement:
+                requirements.add(requirement)
+    return frozenset(requirements)
 
 
 def open_index(path: Path):
@@ -144,8 +166,10 @@ def package_from_stanza(stanza: dict[str, str]) -> Package | None:
         version=stanza.get("Version", ""),
         installed_size=installed_size,
         depends=parse_dependency_groups(dependency_text),
-        conflicts=parse_name_set(", ".join(stanza.get(key, "") for key in ("Conflicts", "Breaks"))),
-        provides=parse_name_set(stanza.get("Provides", "")),
+        conflicts=parse_requirement_set(
+            ", ".join(stanza.get(key, "") for key in ("Conflicts", "Breaks"))
+        ),
+        provides=parse_requirement_set(stanza.get("Provides", "")),
         description=description_lines[0] if description_lines else "",
     )
 
@@ -162,10 +186,12 @@ def default_index_paths(repo_root: Path) -> list[Path]:
     return plain + gz
 
 
-def load_packages(repo_root: Path, indexes: list[Path]) -> tuple[dict[str, Package], dict[str, list[str]]]:
+def load_packages(
+    repo_root: Path, indexes: list[Path]
+) -> tuple[dict[str, list[Package]], dict[str, list[tuple[Package, Requirement]]]]:
     """Load package metadata and virtual-package provider mappings from indexes."""
     paths = indexes or default_index_paths(repo_root)
-    by_name: dict[str, Package] = {}
+    by_name: dict[str, list[Package]] = {}
     seen_paths: set[Path] = set()
 
     for path in paths:
@@ -180,129 +206,369 @@ def load_packages(repo_root: Path, indexes: list[Path]) -> tuple[dict[str, Packa
             package = package_from_stanza(stanza)
             if not package:
                 continue
-            existing = by_name.get(package.name)
-            if existing and existing.installed_size <= package.installed_size:
-                continue
-            by_name[package.name] = package
+            by_name.setdefault(package.name, []).append(package)
 
-    providers: dict[str, list[str]] = {}
-    for package in by_name.values():
+    for versions in by_name.values():
+        versions.sort(key=lambda package: (package.installed_size, package.version))
+
+    providers: dict[str, list[tuple[Package, Requirement]]] = {}
+    for versions in by_name.values():
+        if not versions:
+            continue
+        package = versions[0]
         for provided in package.provides:
-            providers.setdefault(provided, []).append(package.name)
+            providers.setdefault(provided.name, []).append((package, provided))
+
+    for provided_packages in providers.values():
+        provided_packages.sort(key=lambda item: (item[0].installed_size, item[0].name))
 
     return by_name, providers
 
 
-def candidate_names(name: str, packages: dict[str, Package], providers: dict[str, list[str]]) -> list[str]:
+def debian_version_compare(left: str, right: str) -> int:
+    """Compare two Debian package versions using Debian Policy ordering rules."""
+
+    def split_epoch(version: str) -> tuple[int, str]:
+        epoch_text, separator, rest = version.partition(":")
+        if separator and epoch_text.isdigit():
+            return int(epoch_text), rest
+        return 0, version
+
+    def split_revision(version: str) -> tuple[str, str]:
+        upstream, separator, revision = version.rpartition("-")
+        if separator:
+            return upstream, revision
+        return version, "0"
+
+    def char_order(char: str) -> int:
+        if not char:
+            return 0
+        if char == "~":
+            return -1
+        if char.isalpha():
+            return ord(char)
+        return ord(char) + 256
+
+    def compare_part(left_part: str, right_part: str) -> int:
+        left_index = right_index = 0
+        while left_index < len(left_part) or right_index < len(right_part):
+            while (
+                left_index < len(left_part) and not left_part[left_index].isdigit()
+            ) or (
+                right_index < len(right_part) and not right_part[right_index].isdigit()
+            ):
+                left_char = left_part[left_index] if left_index < len(left_part) else ""
+                right_char = (
+                    right_part[right_index] if right_index < len(right_part) else ""
+                )
+                order_delta = char_order(left_char) - char_order(right_char)
+                if order_delta:
+                    return -1 if order_delta < 0 else 1
+                if left_index < len(left_part):
+                    left_index += 1
+                if right_index < len(right_part):
+                    right_index += 1
+
+            left_digit_start = left_index
+            right_digit_start = right_index
+            while left_index < len(left_part) and left_part[left_index].isdigit():
+                left_index += 1
+            while right_index < len(right_part) and right_part[right_index].isdigit():
+                right_index += 1
+
+            left_digits = left_part[left_digit_start:left_index].lstrip("0")
+            right_digits = right_part[right_digit_start:right_index].lstrip("0")
+            if len(left_digits) != len(right_digits):
+                return -1 if len(left_digits) < len(right_digits) else 1
+            if left_digits != right_digits:
+                return -1 if left_digits < right_digits else 1
+
+        return 0
+
+    left_epoch, left_rest = split_epoch(left)
+    right_epoch, right_rest = split_epoch(right)
+    if left_epoch != right_epoch:
+        return -1 if left_epoch < right_epoch else 1
+
+    left_upstream, left_revision = split_revision(left_rest)
+    right_upstream, right_revision = split_revision(right_rest)
+    upstream_result = compare_part(left_upstream, right_upstream)
+    if upstream_result:
+        return upstream_result
+    return compare_part(left_revision, right_revision)
+
+
+def version_satisfies(
+    candidate_version: str, operator: str, required_version: str
+) -> bool:
+    """Return whether a candidate version satisfies a Debian relationship."""
+    if not operator:
+        return True
+    comparison = debian_version_compare(candidate_version, required_version)
+    return {
+        "<<": comparison < 0,
+        "<=": comparison <= 0,
+        "=": comparison == 0,
+        ">=": comparison >= 0,
+        ">>": comparison > 0,
+    }[operator]
+
+
+def package_satisfies(requirement: Requirement, package: Package) -> bool:
+    """Return whether a real package satisfies a requested relationship."""
+    return package.name == requirement.name and version_satisfies(
+        package.version, requirement.operator, requirement.version
+    )
+
+
+def provider_satisfies(requirement: Requirement, provided: Requirement) -> bool:
+    """Return whether a Provides relationship satisfies a virtual package request."""
+    if provided.name != requirement.name:
+        return False
+    if not requirement.operator:
+        return True
+    if not provided.version:
+        return False
+    return version_satisfies(provided.version, requirement.operator, requirement.version)
+
+
+def selected_package_for(
+    requirement: Requirement, selected: dict[str, Package]
+) -> Package | None:
+    """Return the selected package satisfying a real or virtual requirement."""
+    package = selected.get(requirement.name)
+    if package and package_satisfies(requirement, package):
+        return package
+    for package in selected.values():
+        for provided in package.provides:
+            if provider_satisfies(requirement, provided):
+                return package
+    return None
+
+
+def candidate_packages(
+    requirement: Requirement,
+    packages: dict[str, list[Package]],
+    providers: dict[str, list[tuple[Package, Requirement]]],
+) -> list[Package]:
     """Return real packages that satisfy a requested package or virtual name."""
-    names: list[str] = []
-    if name in packages:
-        names.append(name)
-    names.extend(providers.get(name, []))
-    return sorted(dict.fromkeys(names), key=lambda item: packages[item].installed_size)
+    candidates: list[Package] = [
+        package
+        for package in packages.get(requirement.name, [])
+        if package_satisfies(requirement, package)
+    ]
+    candidates.extend(
+        package
+        for package, provided in providers.get(requirement.name, [])
+        if provider_satisfies(requirement, provided)
+    )
+
+    by_name: dict[str, Package] = {}
+    for package in sorted(candidates, key=lambda item: (item.installed_size, item.name)):
+        by_name.setdefault(package.name, package)
+    return list(by_name.values())
 
 
-def estimate_closure_size(
-    name: str,
-    packages: dict[str, Package],
-    providers: dict[str, list[str]],
-    seen: frozenset[str],
-    memo: dict[tuple[str, frozenset[str]], int],
-) -> int:
-    """Estimate the minimal Installed-Size closure for selecting a package name."""
-    cache_key = (name, seen)
+@dataclass(frozen=True)
+class Estimate:
+    """Estimated marginal cost and selected closure for one dependency choice."""
+
+    cost: int
+    selected: dict[str, Package]
+    package: Package | None
+
+
+def requirement_text(requirement: Requirement) -> str:
+    """Render a dependency relationship for diagnostics."""
+    if not requirement.operator:
+        return requirement.name
+    return f"{requirement.name} ({requirement.operator} {requirement.version})"
+
+
+def selected_cache_key(selected: dict[str, Package]) -> tuple[tuple[str, str], ...]:
+    """Build a stable cache key for the current selected package versions."""
+    return tuple(sorted((name, package.version) for name, package in selected.items()))
+
+
+def estimate_package_closure(
+    package: Package,
+    packages: dict[str, list[Package]],
+    providers: dict[str, list[tuple[Package, Requirement]]],
+    selected: dict[str, Package],
+    ancestors: frozenset[str],
+    memo: dict[tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate],
+) -> Estimate:
+    """Estimate marginal cost for adding a package and its dependencies."""
+    if package.name in ancestors:
+        return Estimate(0, selected, package)
+
+    next_selected = dict(selected)
+    cost = 0
+    existing = next_selected.get(package.name)
+    if not existing or existing.version != package.version:
+        cost = package.installed_size
+        next_selected[package.name] = package
+
+    next_ancestors = ancestors | {package.name}
+    for group in package.depends:
+        estimates = [
+            estimate_requirement_closure(
+                requirement, packages, providers, next_selected, next_ancestors, memo
+            )
+            for requirement in group
+        ]
+        best = min(
+            estimates,
+            key=lambda estimate: (
+                estimate.cost,
+                estimate.package.name if estimate.package else "",
+            ),
+        )
+        cost += best.cost
+        next_selected = best.selected
+
+    return Estimate(cost, next_selected, package)
+
+
+def estimate_requirement_closure(
+    requirement: Requirement,
+    packages: dict[str, list[Package]],
+    providers: dict[str, list[tuple[Package, Requirement]]],
+    selected: dict[str, Package],
+    ancestors: frozenset[str],
+    memo: dict[tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate],
+) -> Estimate:
+    """Estimate the marginal closure for satisfying a package relationship."""
+    selected_package = selected_package_for(requirement, selected)
+    if selected_package:
+        return Estimate(0, selected, selected_package)
+
+    cache_key = (requirement, selected_cache_key(selected), ancestors)
     if cache_key in memo:
         return memo[cache_key]
 
-    candidates = candidate_names(name, packages, providers)
+    candidates = candidate_packages(requirement, packages, providers)
     if not candidates:
-        memo[cache_key] = sys.maxsize // 4
-        return memo[cache_key]
+        result = Estimate(sys.maxsize // 4, selected, None)
+        memo[cache_key] = result
+        return result
 
-    best = sys.maxsize // 4
-    for candidate in candidates:
-        if candidate in seen:
-            memo[cache_key] = 0
-            return memo[cache_key]
-        package = packages[candidate]
-        total = package.installed_size
-        next_seen = seen | {candidate}
-        for group in package.depends:
-            total += min(
-                estimate_closure_size(option, packages, providers, next_seen, memo)
-                for option in group
+    result = min(
+        (
+            estimate_package_closure(
+                candidate, packages, providers, selected, ancestors, memo
             )
-        best = min(best, total)
-    memo[cache_key] = best
-    return best
+            for candidate in candidates
+        ),
+        key=lambda estimate: (
+            estimate.cost,
+            estimate.package.name if estimate.package else "",
+        ),
+    )
+    memo[cache_key] = result
+    return result
 
 
 def pick_dependency(
-    alternatives: tuple[str, ...],
-    packages: dict[str, Package],
-    providers: dict[str, list[str]],
+    alternatives: tuple[Requirement, ...],
+    packages: dict[str, list[Package]],
+    providers: dict[str, list[tuple[Package, Requirement]]],
+    selected: dict[str, Package],
     seen: frozenset[str],
-    memo: dict[tuple[str, frozenset[str]], int],
-) -> str | None:
+    memo: dict[tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate],
+) -> Requirement | None:
     """Choose the smallest satisfiable option from a dependency alternative group."""
-    scored: list[tuple[int, str]] = []
-    for alternative in alternatives:
-        for candidate in candidate_names(alternative, packages, providers):
-            scored.append(
-                (estimate_closure_size(candidate, packages, providers, seen, memo), candidate)
-            )
+    scored = [
+        (
+            estimate_requirement_closure(
+                alternative, packages, providers, selected, seen, memo
+            ).cost,
+            requirement_text(alternative),
+            alternative,
+        )
+        for alternative in alternatives
+        if candidate_packages(alternative, packages, providers)
+        or selected_package_for(alternative, selected)
+    ]
     if not scored:
         return None
-    return min(scored)[1]
+    return min(scored)[2]
 
 
 def resolve_targets(
     targets: list[str],
-    packages: dict[str, Package],
-    providers: dict[str, list[str]],
+    packages: dict[str, list[Package]],
+    providers: dict[str, list[tuple[Package, Requirement]]],
 ) -> Resolution:
     """Resolve target packages into a minimal dependency closure plus diagnostics."""
     resolution = Resolution(selected={}, edges={}, missing=[], conflicts=[], roots={})
-    closure_size_memo: dict[tuple[str, frozenset[str]], int] = {}
+    closure_size_memo: dict[
+        tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate
+    ] = {}
 
-    def add_package(name: str, parent: str | None = None, stack: frozenset[str] = frozenset()) -> None:
+    def add_package(
+        requirement: Requirement,
+        parent: str | None = None,
+        stack: frozenset[str] = frozenset(),
+    ) -> None:
         """Add one dependency and recursively expand its selected dependency choices."""
-        candidates = candidate_names(name, packages, providers)
-        if not candidates:
-            resolution.missing.append(name if parent is None else f"{parent} -> {name}")
+        selected_package = selected_package_for(requirement, resolution.selected)
+        if selected_package:
+            if parent:
+                resolution.edges.setdefault(parent, []).append(selected_package.name)
+            elif requirement.name not in resolution.roots:
+                resolution.roots[requirement.name] = selected_package.name
             return
 
-        package_name = min(
+        candidates = candidate_packages(requirement, packages, providers)
+        if not candidates:
+            missing = requirement_text(requirement)
+            resolution.missing.append(
+                missing if parent is None else f"{parent} -> {missing}"
+            )
+            return
+
+        package = min(
             candidates,
-            key=lambda candidate: estimate_closure_size(
+            key=lambda candidate: estimate_package_closure(
                 candidate,
                 packages,
                 providers,
+                dict(resolution.selected),
                 stack,
                 closure_size_memo,
-            ),
+            ).cost,
         )
         if parent is None:
-            resolution.roots[name] = package_name
+            resolution.roots[requirement.name] = package.name
         if parent:
-            resolution.edges.setdefault(parent, []).append(package_name)
+            resolution.edges.setdefault(parent, []).append(package.name)
 
-        if package_name in stack or package_name in resolution.selected:
+        if package.name in stack or package.name in resolution.selected:
             return
 
-        package = packages[package_name]
-        resolution.selected[package_name] = package
-        next_stack = stack | {package_name}
+        resolution.selected[package.name] = package
+        next_stack = stack | {package.name}
 
         for group in package.depends:
-            picked = pick_dependency(group, packages, providers, next_stack, closure_size_memo)
+            picked = pick_dependency(
+                group,
+                packages,
+                providers,
+                dict(resolution.selected),
+                next_stack,
+                closure_size_memo,
+            )
             if not picked:
-                resolution.missing.append(f"{package_name} -> {' | '.join(group)}")
+                resolution.missing.append(
+                    f"{package.name} -> "
+                    f"{' | '.join(requirement_text(item) for item in group)}"
+                )
                 continue
-            add_package(picked, package_name, next_stack)
+            add_package(picked, package.name, next_stack)
 
     for target in targets:
-        add_package(target)
+        add_package(Requirement(target))
 
     detect_conflicts(resolution)
     return resolution
@@ -311,20 +577,20 @@ def resolve_targets(
 def detect_conflicts(resolution: Resolution) -> None:
     """Populate conflict diagnostics for selected packages and provided virtual names."""
     selected = resolution.selected
-    selected_names = set(selected)
-    provided_by: dict[str, set[str]] = {}
-    for package in selected.values():
-        for provided in package.provides:
-            provided_by.setdefault(provided, set()).add(package.name)
 
     for package in selected.values():
-        for conflict in sorted(package.conflicts):
-            if conflict in (selected_names - {package.name}):
-                resolution.conflicts.append(f"{package.name} conflicts with {conflict}")
-                continue
-            other_providers = provided_by.get(conflict, set()) - {package.name}
-            if other_providers:
-                resolution.conflicts.append(f"{package.name} conflicts with {conflict}")
+        for conflict in sorted(package.conflicts, key=requirement_text):
+            for other in selected.values():
+                if other.name == package.name:
+                    continue
+                if package_satisfies(conflict, other) or any(
+                    provider_satisfies(conflict, provided)
+                    for provided in other.provides
+                ):
+                    resolution.conflicts.append(
+                        f"{package.name} conflicts with {requirement_text(conflict)}"
+                    )
+                    break
 
 
 def print_tree(name: str, edges: dict[str, list[str]], indent: str, path: frozenset[str]) -> None:

--- a/apt/scripts/optimize-dependency-tree.py
+++ b/apt/scripts/optimize-dependency-tree.py
@@ -367,12 +367,12 @@ def candidate_packages(
         if provider_satisfies(requirement, provided):
             candidates.append(package)
 
-    by_name: dict[str, Package] = {}
+    by_version: dict[tuple[str, str], Package] = {}
     for package in sorted(
         candidates, key=lambda item: (item.installed_size, item.name, item.version)
     ):
-        by_name.setdefault(package.name, package)
-    return list(by_name.values())
+        by_version.setdefault((package.name, package.version), package)
+    return list(by_version.values())
 
 
 @dataclass(frozen=True)

--- a/apt/scripts/optimize-dependency-tree.py
+++ b/apt/scripts/optimize-dependency-tree.py
@@ -25,6 +25,8 @@ ARCH_RE = re.compile(r":(?:any|native|[a-z0-9-]+)$")
 
 @dataclass(frozen=True)
 class Package:
+    """Normalized package metadata extracted from an APT Packages stanza."""
+
     name: str
     version: str
     installed_size: int
@@ -36,6 +38,8 @@ class Package:
 
 @dataclass
 class Resolution:
+    """Dependency resolution result, including selected packages and diagnostics."""
+
     selected: dict[str, Package]
     edges: dict[str, list[str]]
     missing: list[str]
@@ -44,16 +48,19 @@ class Resolution:
 
     @property
     def total_size(self) -> int:
+        """Return the sum of Installed-Size values for selected packages."""
         return sum(package.installed_size for package in self.selected.values())
 
 
 def normalize_package_name(value: str) -> str:
+    """Strip version constraints and architecture qualifiers from a dependency token."""
     value = VERSION_RE.sub("", value).strip()
     value = ARCH_RE.sub("", value)
     return value.strip()
 
 
 def parse_dependency_groups(value: str) -> tuple[tuple[str, ...], ...]:
+    """Parse Depends/Pre-Depends text into comma groups with pipe alternatives."""
     groups: list[tuple[str, ...]] = []
     for group in DEP_SPLIT_RE.split(value):
         alternatives = tuple(
@@ -67,6 +74,7 @@ def parse_dependency_groups(value: str) -> tuple[tuple[str, ...], ...]:
 
 
 def parse_name_set(value: str) -> frozenset[str]:
+    """Parse a comma/pipe separated relationship field into normalized names."""
     names: set[str] = set()
     for group in DEP_SPLIT_RE.split(value):
         for item in ALT_SPLIT_RE.split(group):
@@ -77,12 +85,14 @@ def parse_name_set(value: str) -> frozenset[str]:
 
 
 def open_index(path: Path):
+    """Open either a plain Packages file or a gzipped Packages.gz index."""
     if path.suffix == ".gz":
         return gzip.open(path, "rt", encoding="utf-8", errors="replace")
     return path.open("r", encoding="utf-8", errors="replace")
 
 
 def read_stanzas(path: Path) -> list[dict[str, str]]:
+    """Read Debian control stanzas, preserving folded continuation lines."""
     stanzas: list[dict[str, str]] = []
     current: dict[str, str] = {}
     current_key: str | None = None
@@ -113,6 +123,7 @@ def read_stanzas(path: Path) -> list[dict[str, str]]:
 
 
 def package_from_stanza(stanza: dict[str, str]) -> Package | None:
+    """Convert one Packages stanza into a Package, skipping malformed entries."""
     name = stanza.get("Package", "")
     if not name:
         return None
@@ -140,6 +151,7 @@ def package_from_stanza(stanza: dict[str, str]) -> Package | None:
 
 
 def default_index_paths(repo_root: Path) -> list[Path]:
+    """Discover Packages indexes below dists/, preferring plain files over gzip twins."""
     dists = repo_root / "dists"
     if not dists.exists():
         return []
@@ -151,6 +163,7 @@ def default_index_paths(repo_root: Path) -> list[Path]:
 
 
 def load_packages(repo_root: Path, indexes: list[Path]) -> tuple[dict[str, Package], dict[str, list[str]]]:
+    """Load package metadata and virtual-package provider mappings from indexes."""
     paths = indexes or default_index_paths(repo_root)
     by_name: dict[str, Package] = {}
     seen_paths: set[Path] = set()
@@ -181,6 +194,7 @@ def load_packages(repo_root: Path, indexes: list[Path]) -> tuple[dict[str, Packa
 
 
 def candidate_names(name: str, packages: dict[str, Package], providers: dict[str, list[str]]) -> list[str]:
+    """Return real packages that satisfy a requested package or virtual name."""
     names: list[str] = []
     if name in packages:
         names.append(name)
@@ -195,6 +209,7 @@ def estimate_closure_size(
     seen: frozenset[str],
     memo: dict[tuple[str, frozenset[str]], int],
 ) -> int:
+    """Estimate the minimal Installed-Size closure for selecting a package name."""
     cache_key = (name, seen)
     if cache_key in memo:
         return memo[cache_key]
@@ -229,6 +244,7 @@ def pick_dependency(
     seen: frozenset[str],
     memo: dict[tuple[str, frozenset[str]], int],
 ) -> str | None:
+    """Choose the smallest satisfiable option from a dependency alternative group."""
     scored: list[tuple[int, str]] = []
     for alternative in alternatives:
         for candidate in candidate_names(alternative, packages, providers):
@@ -245,10 +261,12 @@ def resolve_targets(
     packages: dict[str, Package],
     providers: dict[str, list[str]],
 ) -> Resolution:
+    """Resolve target packages into a minimal dependency closure plus diagnostics."""
     resolution = Resolution(selected={}, edges={}, missing=[], conflicts=[], roots={})
     closure_size_memo: dict[tuple[str, frozenset[str]], int] = {}
 
     def add_package(name: str, parent: str | None = None, stack: frozenset[str] = frozenset()) -> None:
+        """Add one dependency and recursively expand its selected dependency choices."""
         candidates = candidate_names(name, packages, providers)
         if not candidates:
             resolution.missing.append(name if parent is None else f"{parent} -> {name}")
@@ -291,6 +309,7 @@ def resolve_targets(
 
 
 def detect_conflicts(resolution: Resolution) -> None:
+    """Populate conflict diagnostics for selected packages and provided virtual names."""
     selected = resolution.selected
     selected_names = set(selected)
     provided_by: dict[str, set[str]] = {}
@@ -309,6 +328,7 @@ def detect_conflicts(resolution: Resolution) -> None:
 
 
 def print_tree(name: str, edges: dict[str, list[str]], indent: str, path: frozenset[str]) -> None:
+    """Print a dependency tree, avoiding infinite recursion on cycles."""
     print(f"{indent}- {name}")
     if name in path:
         print(f"{indent}  (cycle skipped)")
@@ -319,6 +339,7 @@ def print_tree(name: str, edges: dict[str, list[str]], indent: str, path: frozen
 
 
 def print_dot(resolution: Resolution) -> None:
+    """Print the selected dependency graph in Graphviz DOT format."""
     print("digraph dependencies {")
     print('  rankdir="LR";')
     for name in sorted(resolution.selected):
@@ -330,6 +351,7 @@ def print_dot(resolution: Resolution) -> None:
 
 
 def print_summary(targets: list[str], resolution: Resolution, show_dot: bool) -> None:
+    """Print a human-readable dependency plan and optional graph output."""
     print("Optimized dependency plan")
     print("=========================")
     print(f"Targets: {', '.join(targets)}")
@@ -371,6 +393,7 @@ def print_summary(targets: list[str], resolution: Resolution, show_dot: bool) ->
 
 
 def main(argv: list[str]) -> int:
+    """Parse CLI arguments, run dependency resolution, and return a process status."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("packages", nargs="+", help="Target package names or virtual packages")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="APT repository root")

--- a/apt/scripts/optimize-dependency-tree.py
+++ b/apt/scripts/optimize-dependency-tree.py
@@ -213,14 +213,14 @@ def load_packages(
 
     providers: dict[str, list[tuple[Package, Requirement]]] = {}
     for versions in by_name.values():
-        if not versions:
-            continue
-        package = versions[0]
-        for provided in package.provides:
-            providers.setdefault(provided.name, []).append((package, provided))
+        for package in versions:
+            for provided in package.provides:
+                providers.setdefault(provided.name, []).append((package, provided))
 
     for provided_packages in providers.values():
-        provided_packages.sort(key=lambda item: (item[0].installed_size, item[0].name))
+        provided_packages.sort(
+            key=lambda item: (item[0].installed_size, item[0].name, item[0].version)
+        )
 
     return by_name, providers
 
@@ -252,22 +252,25 @@ def debian_version_compare(left: str, right: str) -> int:
     def compare_part(left_part: str, right_part: str) -> int:
         left_index = right_index = 0
         while left_index < len(left_part) or right_index < len(right_part):
-            while (
-                left_index < len(left_part) and not left_part[left_index].isdigit()
-            ) or (
-                right_index < len(right_part) and not right_part[right_index].isdigit()
-            ):
-                left_char = left_part[left_index] if left_index < len(left_part) else ""
+            left_non_digit_start = left_index
+            right_non_digit_start = right_index
+            while left_index < len(left_part) and not left_part[left_index].isdigit():
+                left_index += 1
+            while right_index < len(right_part) and not right_part[right_index].isdigit():
+                right_index += 1
+
+            left_non_digits = left_part[left_non_digit_start:left_index]
+            right_non_digits = right_part[right_non_digit_start:right_index]
+            for offset in range(max(len(left_non_digits), len(right_non_digits))):
+                left_char = (
+                    left_non_digits[offset] if offset < len(left_non_digits) else ""
+                )
                 right_char = (
-                    right_part[right_index] if right_index < len(right_part) else ""
+                    right_non_digits[offset] if offset < len(right_non_digits) else ""
                 )
                 order_delta = char_order(left_char) - char_order(right_char)
                 if order_delta:
                     return -1 if order_delta < 0 else 1
-                if left_index < len(left_part):
-                    left_index += 1
-                if right_index < len(right_part):
-                    right_index += 1
 
             left_digit_start = left_index
             right_digit_start = right_index
@@ -357,14 +360,17 @@ def candidate_packages(
         for package in packages.get(requirement.name, [])
         if package_satisfies(requirement, package)
     ]
-    candidates.extend(
-        package
-        for package, provided in providers.get(requirement.name, [])
-        if provider_satisfies(requirement, provided)
-    )
+    for package, provided in providers.get(requirement.name, []):
+        default_package = packages.get(package.name, [None])[0]
+        if not requirement.operator and package != default_package:
+            continue
+        if provider_satisfies(requirement, provided):
+            candidates.append(package)
 
     by_name: dict[str, Package] = {}
-    for package in sorted(candidates, key=lambda item: (item.installed_size, item.name)):
+    for package in sorted(
+        candidates, key=lambda item: (item.installed_size, item.name, item.version)
+    ):
         by_name.setdefault(package.name, package)
     return list(by_name.values())
 
@@ -385,9 +391,9 @@ def requirement_text(requirement: Requirement) -> str:
     return f"{requirement.name} ({requirement.operator} {requirement.version})"
 
 
-def selected_cache_key(selected: dict[str, Package]) -> tuple[tuple[str, str], ...]:
+def selected_cache_key(selected: dict[str, Package]) -> frozenset[tuple[str, str]]:
     """Build a stable cache key for the current selected package versions."""
-    return tuple(sorted((name, package.version) for name, package in selected.items()))
+    return frozenset((name, package.version) for name, package in selected.items())
 
 
 def estimate_package_closure(
@@ -396,7 +402,7 @@ def estimate_package_closure(
     providers: dict[str, list[tuple[Package, Requirement]]],
     selected: dict[str, Package],
     ancestors: frozenset[str],
-    memo: dict[tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate],
+    memo: dict[tuple[Requirement, frozenset[tuple[str, str]], frozenset[str]], Estimate],
 ) -> Estimate:
     """Estimate marginal cost for adding a package and its dependencies."""
     if package.name in ancestors:
@@ -436,7 +442,7 @@ def estimate_requirement_closure(
     providers: dict[str, list[tuple[Package, Requirement]]],
     selected: dict[str, Package],
     ancestors: frozenset[str],
-    memo: dict[tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate],
+    memo: dict[tuple[Requirement, frozenset[tuple[str, str]], frozenset[str]], Estimate],
 ) -> Estimate:
     """Estimate the marginal closure for satisfying a package relationship."""
     selected_package = selected_package_for(requirement, selected)
@@ -475,7 +481,7 @@ def pick_dependency(
     providers: dict[str, list[tuple[Package, Requirement]]],
     selected: dict[str, Package],
     seen: frozenset[str],
-    memo: dict[tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate],
+    memo: dict[tuple[Requirement, frozenset[tuple[str, str]], frozenset[str]], Estimate],
 ) -> Requirement | None:
     """Choose the smallest satisfiable option from a dependency alternative group."""
     scored = [
@@ -484,15 +490,16 @@ def pick_dependency(
                 alternative, packages, providers, selected, seen, memo
             ).cost,
             requirement_text(alternative),
+            index,
             alternative,
         )
-        for alternative in alternatives
+        for index, alternative in enumerate(alternatives)
         if candidate_packages(alternative, packages, providers)
         or selected_package_for(alternative, selected)
     ]
     if not scored:
         return None
-    return min(scored)[2]
+    return min(scored)[3]
 
 
 def resolve_targets(
@@ -503,7 +510,7 @@ def resolve_targets(
     """Resolve target packages into a minimal dependency closure plus diagnostics."""
     resolution = Resolution(selected={}, edges={}, missing=[], conflicts=[], roots={})
     closure_size_memo: dict[
-        tuple[Requirement, tuple[tuple[str, str], ...], frozenset[str]], Estimate
+        tuple[Requirement, frozenset[tuple[str, str]], frozenset[str]], Estimate
     ] = {}
 
     def add_package(

--- a/apt/scripts/optimize-dependency-tree.py
+++ b/apt/scripts/optimize-dependency-tree.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BUSL-1.1
+"""Optimize package dependency trees from local APT Packages indexes.
+
+The helper is intentionally read-only. It never calls apt, dpkg, sudo, or the
+network; it only inspects Packages/Packages.gz metadata and produces a suggested
+minimal dependency closure for review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEP_SPLIT_RE = re.compile(r"\s*,\s*")
+ALT_SPLIT_RE = re.compile(r"\s*\|\s*")
+VERSION_RE = re.compile(r"\s*\([^)]*\)")
+ARCH_RE = re.compile(r":(?:any|native|[a-z0-9-]+)$")
+
+
+@dataclass(frozen=True)
+class Package:
+    name: str
+    version: str
+    installed_size: int
+    depends: tuple[tuple[str, ...], ...]
+    conflicts: frozenset[str]
+    provides: frozenset[str]
+    description: str
+
+
+@dataclass
+class Resolution:
+    selected: dict[str, Package]
+    edges: dict[str, list[str]]
+    missing: list[str]
+    conflicts: list[str]
+    roots: dict[str, str]
+
+    @property
+    def total_size(self) -> int:
+        return sum(package.installed_size for package in self.selected.values())
+
+
+def normalize_package_name(value: str) -> str:
+    value = VERSION_RE.sub("", value).strip()
+    value = ARCH_RE.sub("", value)
+    return value.strip()
+
+
+def parse_dependency_groups(value: str) -> tuple[tuple[str, ...], ...]:
+    groups: list[tuple[str, ...]] = []
+    for group in DEP_SPLIT_RE.split(value):
+        alternatives = tuple(
+            name
+            for name in (normalize_package_name(item) for item in ALT_SPLIT_RE.split(group))
+            if name
+        )
+        if alternatives:
+            groups.append(alternatives)
+    return tuple(groups)
+
+
+def parse_name_set(value: str) -> frozenset[str]:
+    names: set[str] = set()
+    for group in DEP_SPLIT_RE.split(value):
+        for item in ALT_SPLIT_RE.split(group):
+            name = normalize_package_name(item)
+            if name:
+                names.add(name)
+    return frozenset(names)
+
+
+def open_index(path: Path):
+    if path.suffix == ".gz":
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return path.open("r", encoding="utf-8", errors="replace")
+
+
+def read_stanzas(path: Path) -> list[dict[str, str]]:
+    stanzas: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    current_key: str | None = None
+
+    with open_index(path) as handle:
+        for raw_line in handle:
+            line = raw_line.rstrip("\n")
+            if not line:
+                if current:
+                    stanzas.append(current)
+                current = {}
+                current_key = None
+                continue
+
+            if line.startswith(" ") and current_key:
+                current[current_key] = f"{current[current_key]}\n{line.strip()}"
+                continue
+
+            key, separator, value = line.partition(":")
+            if separator:
+                current_key = key
+                current[key] = value.strip()
+
+    if current:
+        stanzas.append(current)
+
+    return stanzas
+
+
+def package_from_stanza(stanza: dict[str, str]) -> Package | None:
+    name = stanza.get("Package", "")
+    if not name:
+        return None
+
+    try:
+        installed_size = int(stanza.get("Installed-Size", "0"))
+    except ValueError:
+        installed_size = 0
+
+    dependency_text = ", ".join(
+        value for key in ("Pre-Depends", "Depends") if (value := stanza.get(key))
+    )
+
+    return Package(
+        name=name,
+        version=stanza.get("Version", ""),
+        installed_size=installed_size,
+        depends=parse_dependency_groups(dependency_text),
+        conflicts=parse_name_set(", ".join(stanza.get(key, "") for key in ("Conflicts", "Breaks"))),
+        provides=parse_name_set(stanza.get("Provides", "")),
+        description=stanza.get("Description", "").splitlines()[0],
+    )
+
+
+def default_index_paths(repo_root: Path) -> list[Path]:
+    dists = repo_root / "dists"
+    if not dists.exists():
+        return []
+
+    plain = sorted(dists.glob("**/Packages"))
+    plain_dirs = {path.parent for path in plain}
+    gz = sorted(path for path in dists.glob("**/Packages.gz") if path.parent not in plain_dirs)
+    return plain + gz
+
+
+def load_packages(repo_root: Path, indexes: list[Path]) -> tuple[dict[str, Package], dict[str, list[str]]]:
+    paths = indexes or default_index_paths(repo_root)
+    by_name: dict[str, Package] = {}
+    providers: dict[str, list[str]] = {}
+    seen_paths: set[Path] = set()
+
+    for path in paths:
+        path = path.resolve()
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        if not path.exists():
+            raise FileNotFoundError(f"package index not found: {path}")
+
+        for stanza in read_stanzas(path):
+            package = package_from_stanza(stanza)
+            if not package:
+                continue
+            existing = by_name.get(package.name)
+            if existing and existing.installed_size <= package.installed_size:
+                continue
+            by_name[package.name] = package
+            for provided in package.provides:
+                providers.setdefault(provided, []).append(package.name)
+
+    return by_name, providers
+
+
+def candidate_names(name: str, packages: dict[str, Package], providers: dict[str, list[str]]) -> list[str]:
+    names: list[str] = []
+    if name in packages:
+        names.append(name)
+    names.extend(providers.get(name, []))
+    return sorted(dict.fromkeys(names), key=lambda item: packages[item].installed_size)
+
+
+def estimate_closure_size(
+    name: str,
+    packages: dict[str, Package],
+    providers: dict[str, list[str]],
+    seen: frozenset[str],
+) -> int:
+    candidates = candidate_names(name, packages, providers)
+    if not candidates:
+        return sys.maxsize // 4
+
+    best = sys.maxsize // 4
+    for candidate in candidates:
+        if candidate in seen:
+            return 0
+        package = packages[candidate]
+        total = package.installed_size
+        next_seen = seen | {candidate}
+        for group in package.depends:
+            total += min(
+                estimate_closure_size(option, packages, providers, next_seen) for option in group
+            )
+        best = min(best, total)
+    return best
+
+
+def pick_dependency(
+    alternatives: tuple[str, ...],
+    packages: dict[str, Package],
+    providers: dict[str, list[str]],
+    seen: frozenset[str],
+) -> str | None:
+    scored: list[tuple[int, str]] = []
+    for alternative in alternatives:
+        for candidate in candidate_names(alternative, packages, providers):
+            scored.append((estimate_closure_size(candidate, packages, providers, seen), candidate))
+    if not scored:
+        return None
+    return min(scored)[1]
+
+
+def resolve_targets(
+    targets: list[str],
+    packages: dict[str, Package],
+    providers: dict[str, list[str]],
+) -> Resolution:
+    resolution = Resolution(selected={}, edges={}, missing=[], conflicts=[], roots={})
+
+    def add_package(name: str, parent: str | None = None, stack: frozenset[str] = frozenset()) -> None:
+        candidates = candidate_names(name, packages, providers)
+        if not candidates:
+            resolution.missing.append(name if parent is None else f"{parent} -> {name}")
+            return
+
+        package_name = min(
+            candidates,
+            key=lambda candidate: estimate_closure_size(candidate, packages, providers, stack),
+        )
+        if parent is None:
+            resolution.roots[name] = package_name
+        if parent:
+            resolution.edges.setdefault(parent, []).append(package_name)
+
+        if package_name in stack or package_name in resolution.selected:
+            return
+
+        package = packages[package_name]
+        resolution.selected[package_name] = package
+        next_stack = stack | {package_name}
+
+        for group in package.depends:
+            picked = pick_dependency(group, packages, providers, next_stack)
+            if not picked:
+                resolution.missing.append(f"{package_name} -> {' | '.join(group)}")
+                continue
+            add_package(picked, package_name, next_stack)
+
+    for target in targets:
+        add_package(target)
+
+    detect_conflicts(resolution)
+    return resolution
+
+
+def detect_conflicts(resolution: Resolution) -> None:
+    selected = resolution.selected
+    selected_names = set(selected)
+    virtuals = {provided for package in selected.values() for provided in package.provides}
+    selected_or_provided = selected_names | virtuals
+
+    for package in selected.values():
+        for conflict in sorted(package.conflicts & selected_or_provided):
+            resolution.conflicts.append(f"{package.name} conflicts with {conflict}")
+
+
+def print_tree(name: str, edges: dict[str, list[str]], indent: str, seen: set[str]) -> None:
+    print(f"{indent}- {name}")
+    if name in seen:
+        print(f"{indent}  (cycle skipped)")
+        return
+    seen.add(name)
+    for child in sorted(dict.fromkeys(edges.get(name, []))):
+        print_tree(child, edges, f"{indent}  ", seen)
+
+
+def print_dot(resolution: Resolution) -> None:
+    print("digraph dependencies {")
+    print('  rankdir="LR";')
+    for name in sorted(resolution.selected):
+        print(f'  "{name}";')
+    for parent, children in sorted(resolution.edges.items()):
+        for child in sorted(dict.fromkeys(children)):
+            print(f'  "{parent}" -> "{child}";')
+    print("}")
+
+
+def print_summary(targets: list[str], resolution: Resolution, show_dot: bool) -> None:
+    print("Optimized dependency plan")
+    print("=========================")
+    print(f"Targets: {', '.join(targets)}")
+    print(f"Selected packages: {len(resolution.selected)}")
+    print(f"Total Installed-Size: {resolution.total_size} KiB")
+    print()
+
+    print("Package closure:")
+    for name in sorted(resolution.selected):
+        package = resolution.selected[name]
+        version = f" {package.version}" if package.version else ""
+        description = f" - {package.description}" if package.description else ""
+        print(f"  - {name}{version} ({package.installed_size} KiB){description}")
+    print()
+
+    print("Dependency tree:")
+    for target in targets:
+        root = resolution.roots.get(target, target)
+        print_tree(root, resolution.edges, "", set())
+    print()
+
+    if resolution.missing:
+        print("Missing dependencies:")
+        for missing in sorted(dict.fromkeys(resolution.missing)):
+            print(f"  - {missing}")
+    else:
+        print("Missing dependencies: none")
+
+    if resolution.conflicts:
+        print("Conflicts:")
+        for conflict in sorted(dict.fromkeys(resolution.conflicts)):
+            print(f"  - {conflict}")
+    else:
+        print("Conflicts: none")
+
+    if show_dot:
+        print()
+        print_dot(resolution)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packages", nargs="+", help="Target package names or virtual packages")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="APT repository root")
+    parser.add_argument("--index", type=Path, action="append", default=[], help="Packages or Packages.gz file")
+    parser.add_argument("--dot", action="store_true", help="Include Graphviz DOT output")
+    args = parser.parse_args(argv)
+
+    try:
+        packages, providers = load_packages(args.repo_root, args.index)
+    except OSError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    if not packages:
+        print("No package indexes found. Pass --index or run from an APT repository root.", file=sys.stderr)
+        return 2
+
+    resolution = resolve_targets(args.packages, packages, providers)
+    print_summary(args.packages, resolution, args.dot)
+
+    if resolution.missing or resolution.conflicts:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/apt/scripts/optimize-dependency-tree.py
+++ b/apt/scripts/optimize-dependency-tree.py
@@ -97,7 +97,7 @@ def read_stanzas(path: Path) -> list[dict[str, str]]:
                 current_key = None
                 continue
 
-            if line.startswith(" ") and current_key:
+            if line.startswith((" ", "\t")) and current_key:
                 current[current_key] = f"{current[current_key]}\n{line.strip()}"
                 continue
 
@@ -126,6 +126,8 @@ def package_from_stanza(stanza: dict[str, str]) -> Package | None:
         value for key in ("Pre-Depends", "Depends") if (value := stanza.get(key))
     )
 
+    description_lines = stanza.get("Description", "").splitlines()
+
     return Package(
         name=name,
         version=stanza.get("Version", ""),
@@ -133,7 +135,7 @@ def package_from_stanza(stanza: dict[str, str]) -> Package | None:
         depends=parse_dependency_groups(dependency_text),
         conflicts=parse_name_set(", ".join(stanza.get(key, "") for key in ("Conflicts", "Breaks"))),
         provides=parse_name_set(stanza.get("Provides", "")),
-        description=stanza.get("Description", "").splitlines()[0],
+        description=description_lines[0] if description_lines else "",
     )
 
 
@@ -151,7 +153,6 @@ def default_index_paths(repo_root: Path) -> list[Path]:
 def load_packages(repo_root: Path, indexes: list[Path]) -> tuple[dict[str, Package], dict[str, list[str]]]:
     paths = indexes or default_index_paths(repo_root)
     by_name: dict[str, Package] = {}
-    providers: dict[str, list[str]] = {}
     seen_paths: set[Path] = set()
 
     for path in paths:
@@ -170,8 +171,11 @@ def load_packages(repo_root: Path, indexes: list[Path]) -> tuple[dict[str, Packa
             if existing and existing.installed_size <= package.installed_size:
                 continue
             by_name[package.name] = package
-            for provided in package.provides:
-                providers.setdefault(provided, []).append(package.name)
+
+    providers: dict[str, list[str]] = {}
+    for package in by_name.values():
+        for provided in package.provides:
+            providers.setdefault(provided, []).append(package.name)
 
     return by_name, providers
 
@@ -189,23 +193,32 @@ def estimate_closure_size(
     packages: dict[str, Package],
     providers: dict[str, list[str]],
     seen: frozenset[str],
+    memo: dict[tuple[str, frozenset[str]], int],
 ) -> int:
+    cache_key = (name, seen)
+    if cache_key in memo:
+        return memo[cache_key]
+
     candidates = candidate_names(name, packages, providers)
     if not candidates:
-        return sys.maxsize // 4
+        memo[cache_key] = sys.maxsize // 4
+        return memo[cache_key]
 
     best = sys.maxsize // 4
     for candidate in candidates:
         if candidate in seen:
-            return 0
+            memo[cache_key] = 0
+            return memo[cache_key]
         package = packages[candidate]
         total = package.installed_size
         next_seen = seen | {candidate}
         for group in package.depends:
             total += min(
-                estimate_closure_size(option, packages, providers, next_seen) for option in group
+                estimate_closure_size(option, packages, providers, next_seen, memo)
+                for option in group
             )
         best = min(best, total)
+    memo[cache_key] = best
     return best
 
 
@@ -214,11 +227,14 @@ def pick_dependency(
     packages: dict[str, Package],
     providers: dict[str, list[str]],
     seen: frozenset[str],
+    memo: dict[tuple[str, frozenset[str]], int],
 ) -> str | None:
     scored: list[tuple[int, str]] = []
     for alternative in alternatives:
         for candidate in candidate_names(alternative, packages, providers):
-            scored.append((estimate_closure_size(candidate, packages, providers, seen), candidate))
+            scored.append(
+                (estimate_closure_size(candidate, packages, providers, seen, memo), candidate)
+            )
     if not scored:
         return None
     return min(scored)[1]
@@ -230,6 +246,7 @@ def resolve_targets(
     providers: dict[str, list[str]],
 ) -> Resolution:
     resolution = Resolution(selected={}, edges={}, missing=[], conflicts=[], roots={})
+    closure_size_memo: dict[tuple[str, frozenset[str]], int] = {}
 
     def add_package(name: str, parent: str | None = None, stack: frozenset[str] = frozenset()) -> None:
         candidates = candidate_names(name, packages, providers)
@@ -239,7 +256,13 @@ def resolve_targets(
 
         package_name = min(
             candidates,
-            key=lambda candidate: estimate_closure_size(candidate, packages, providers, stack),
+            key=lambda candidate: estimate_closure_size(
+                candidate,
+                packages,
+                providers,
+                stack,
+                closure_size_memo,
+            ),
         )
         if parent is None:
             resolution.roots[name] = package_name
@@ -254,7 +277,7 @@ def resolve_targets(
         next_stack = stack | {package_name}
 
         for group in package.depends:
-            picked = pick_dependency(group, packages, providers, next_stack)
+            picked = pick_dependency(group, packages, providers, next_stack, closure_size_memo)
             if not picked:
                 resolution.missing.append(f"{package_name} -> {' | '.join(group)}")
                 continue
@@ -270,22 +293,29 @@ def resolve_targets(
 def detect_conflicts(resolution: Resolution) -> None:
     selected = resolution.selected
     selected_names = set(selected)
-    virtuals = {provided for package in selected.values() for provided in package.provides}
-    selected_or_provided = selected_names | virtuals
+    provided_by: dict[str, set[str]] = {}
+    for package in selected.values():
+        for provided in package.provides:
+            provided_by.setdefault(provided, set()).add(package.name)
 
     for package in selected.values():
-        for conflict in sorted(package.conflicts & selected_or_provided):
-            resolution.conflicts.append(f"{package.name} conflicts with {conflict}")
+        for conflict in sorted(package.conflicts):
+            if conflict in (selected_names - {package.name}):
+                resolution.conflicts.append(f"{package.name} conflicts with {conflict}")
+                continue
+            other_providers = provided_by.get(conflict, set()) - {package.name}
+            if other_providers:
+                resolution.conflicts.append(f"{package.name} conflicts with {conflict}")
 
 
-def print_tree(name: str, edges: dict[str, list[str]], indent: str, seen: set[str]) -> None:
+def print_tree(name: str, edges: dict[str, list[str]], indent: str, path: frozenset[str]) -> None:
     print(f"{indent}- {name}")
-    if name in seen:
+    if name in path:
         print(f"{indent}  (cycle skipped)")
         return
-    seen.add(name)
+    next_path = path | {name}
     for child in sorted(dict.fromkeys(edges.get(name, []))):
-        print_tree(child, edges, f"{indent}  ", seen)
+        print_tree(child, edges, f"{indent}  ", next_path)
 
 
 def print_dot(resolution: Resolution) -> None:
@@ -318,7 +348,7 @@ def print_summary(targets: list[str], resolution: Resolution, show_dot: bool) ->
     print("Dependency tree:")
     for target in targets:
         root = resolution.roots.get(target, target)
-        print_tree(root, resolution.edges, "", set())
+        print_tree(root, resolution.edges, "", frozenset())
     print()
 
     if resolution.missing:

--- a/tests/optimize-dependency-tree-test.sh
+++ b/tests/optimize-dependency-tree-test.sh
@@ -112,6 +112,22 @@ Version: 2.0
 Installed-Size: 20
 Description: compatible newer direct dependency
 
+Package: ordered-version-root
+Version: 1.0
+Installed-Size: 1
+Depends: ordered-version-lib (>= 2.0)
+Description: package requiring a newer direct dependency listed before an older one
+
+Package: ordered-version-lib
+Version: 2.0
+Installed-Size: 20
+Description: compatible direct dependency listed first
+
+Package: ordered-version-lib
+Version: 1.0
+Installed-Size: 1
+Description: incompatible older direct dependency listed last
+
 Package: virtual-version-root
 Version: 1.0
 Installed-Size: 1
@@ -129,6 +145,45 @@ Version: 1.0
 Installed-Size: 20
 Provides: virtual-api (= 2.0)
 Description: compatible virtual provider
+
+Package: same-provider-root
+Version: 1.0
+Installed-Size: 1
+Depends: same-virtual (>= 2.0)
+Description: package requiring a virtual dependency provided by a later version
+
+Package: same-provider
+Version: 1.0
+Installed-Size: 1
+Description: smaller same-name package without the virtual provide
+
+Package: same-provider
+Version: 2.0
+Installed-Size: 20
+Provides: same-virtual (= 2.0)
+Description: larger same-name package with the versioned virtual provide
+
+Package: duplicate-alt-root
+Version: 1.0
+Installed-Size: 1
+Depends: shared-lib | shared-lib
+Description: root with duplicate alternatives
+
+Package: digit-letter-root
+Version: 1.0
+Installed-Size: 1
+Depends: digit-letter-lib (<< 1.a)
+Description: root with a dependency that compares digits against non-digits
+
+Package: digit-letter-lib
+Version: 1.2
+Installed-Size: 1
+Description: version whose digit segment sorts before the letter segment
+
+Package: digit-letter-lib
+Version: 1.a
+Installed-Size: 20
+Description: version whose letter segment sorts after the digit segment
 
 Package: marginal-root
 Version: 1.0
@@ -230,9 +285,24 @@ output="$(run_optimizer versioned-root)"
 assert_contains "$output" "versioned-lib 2.0"
 assert_not_contains "$output" "versioned-lib 1.0"
 
+output="$(run_optimizer ordered-version-root)"
+assert_contains "$output" "ordered-version-lib 2.0"
+assert_not_contains "$output" "ordered-version-lib 1.0"
+
 output="$(run_optimizer virtual-version-root)"
 assert_contains "$output" "provider-new 1.0"
 assert_not_contains "$output" "provider-old 1.0"
+
+output="$(run_optimizer same-provider-root)"
+assert_contains "$output" "same-provider 2.0"
+assert_not_contains "$output" "same-provider 1.0"
+
+output="$(run_optimizer duplicate-alt-root)"
+assert_contains "$output" "shared-lib 2.0"
+
+output="$(run_optimizer digit-letter-root)"
+assert_contains "$output" "digit-letter-lib 1.2"
+assert_not_contains "$output" "digit-letter-lib 1.a"
 
 output="$(run_optimizer marginal-root)"
 assert_contains "$output" "Total Installed-Size: 102 KiB"

--- a/tests/optimize-dependency-tree-test.sh
+++ b/tests/optimize-dependency-tree-test.sh
@@ -43,6 +43,58 @@ Version: 1.0
 Installed-Size: 20
 Depends: runtime-virtual
 Description: virtual package consumer
+
+Package: no-description
+Version: 1.0
+Installed-Size: 3
+
+Package: tab-dep-root
+Version: 1.0
+Installed-Size: 4
+Depends:
+	shared-lib
+Description: dependency continued with a tab
+
+Package: renamed-self
+Version: 1.0
+Installed-Size: 12
+Provides: old-self
+Conflicts: old-self
+Description: package that conflicts only with its own virtual package
+
+Package: renamed-tool
+Version: 1.0
+Installed-Size: 100
+Provides: old-tool
+Description: larger obsolete provider
+
+Package: renamed-tool
+Version: 2.0
+Installed-Size: 10
+Description: smaller replacement that no longer provides old-tool
+
+Package: diamond-root
+Version: 1.0
+Installed-Size: 1
+Depends: diamond-left, diamond-right
+Description: root with shared transitive dependency
+
+Package: diamond-left
+Version: 1.0
+Installed-Size: 1
+Depends: diamond-shared
+Description: left dependency
+
+Package: diamond-right
+Version: 1.0
+Installed-Size: 1
+Depends: diamond-shared
+Description: right dependency
+
+Package: diamond-shared
+Version: 1.0
+Installed-Size: 1
+Description: shared dependency
 EOF
 
 gzip -c "$INDEX" > "$GZ_INDEX"
@@ -52,6 +104,16 @@ assert_contains() {
     local needle="$2"
     if [[ "$haystack" != *"$needle"* ]]; then
         echo "Expected output to contain: $needle" >&2
+        echo "$haystack" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "Expected output not to contain: $needle" >&2
         echo "$haystack" >&2
         exit 1
     fi
@@ -84,6 +146,29 @@ assert_contains "$output" "tiny-runtime 1.0"
 output="$(run_optimizer runtime-virtual)"
 assert_contains "$output" "- tiny-runtime"
 assert_contains "$output" "Total Installed-Size: 45 KiB"
+
+output="$(run_optimizer no-description)"
+assert_contains "$output" "Selected packages: 1"
+assert_contains "$output" "no-description 1.0"
+
+output="$(run_optimizer tab-dep-root)"
+assert_contains "$output" "Selected packages: 2"
+assert_contains "$output" "shared-lib 2.0"
+
+output="$(run_optimizer renamed-self)"
+assert_contains "$output" "renamed-self 1.0"
+assert_contains "$output" "Conflicts: none"
+
+if run_optimizer old-tool > "$TMP_DIR/stale-provider.out" 2>&1; then
+    echo "Expected stale virtual provider lookup to fail" >&2
+    cat "$TMP_DIR/stale-provider.out" >&2
+    exit 1
+fi
+assert_contains "$(cat "$TMP_DIR/stale-provider.out")" "Missing dependencies:"
+
+output="$(run_optimizer diamond-root)"
+assert_contains "$output" "diamond-shared 1.0"
+assert_not_contains "$output" "(cycle skipped)"
 
 if run_optimizer cx-demo conflict-tool > "$TMP_DIR/conflict.out" 2>&1; then
     echo "Expected conflicting plan to fail" >&2

--- a/tests/optimize-dependency-tree-test.sh
+++ b/tests/optimize-dependency-tree-test.sh
@@ -172,18 +172,40 @@ Description: root with duplicate alternatives
 Package: digit-letter-root
 Version: 1.0
 Installed-Size: 1
-Depends: digit-letter-lib (<< 1.a)
-Description: root with a dependency that compares digits against non-digits
+Depends: digit-letter-lib (<< 1.0)
+Description: root with a dependency that compares tilde versions using Debian ordering
 
 Package: digit-letter-lib
-Version: 1.2
+Version: 1.0
 Installed-Size: 1
-Description: version whose digit segment sorts before the letter segment
+Description: final version that sorts lexically before the release candidate
 
 Package: digit-letter-lib
-Version: 1.a
+Version: 1.0~rc1
 Installed-Size: 20
-Description: version whose letter segment sorts after the digit segment
+Description: release candidate that sorts before the final version in Debian ordering
+
+Package: closure-version-root
+Version: 1.0
+Installed-Size: 1
+Depends: closure-version-lib
+Description: root where a larger package version has a smaller dependency closure
+
+Package: closure-version-lib
+Version: 1.0
+Installed-Size: 1
+Depends: closure-heavy-runtime
+Description: smaller package version with a large dependency
+
+Package: closure-version-lib
+Version: 2.0
+Installed-Size: 20
+Description: larger package version with no extra dependency
+
+Package: closure-heavy-runtime
+Version: 1.0
+Installed-Size: 100
+Description: large transitive dependency for the older version
 
 Package: marginal-root
 Version: 1.0
@@ -301,8 +323,13 @@ output="$(run_optimizer duplicate-alt-root)"
 assert_contains "$output" "shared-lib 2.0"
 
 output="$(run_optimizer digit-letter-root)"
-assert_contains "$output" "digit-letter-lib 1.2"
-assert_not_contains "$output" "digit-letter-lib 1.a"
+assert_contains "$output" "digit-letter-lib 1.0~rc1"
+assert_not_contains "$output" "digit-letter-lib 1.0 (1 KiB)"
+
+output="$(run_optimizer closure-version-root)"
+assert_contains "$output" "closure-version-lib 2.0"
+assert_not_contains "$output" "closure-version-lib 1.0"
+assert_not_contains "$output" "closure-heavy-runtime 1.0"
 
 output="$(run_optimizer marginal-root)"
 assert_contains "$output" "Total Installed-Size: 102 KiB"

--- a/tests/optimize-dependency-tree-test.sh
+++ b/tests/optimize-dependency-tree-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BUSL-1.1
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INDEX="$TMP_DIR/Packages"
+GZ_INDEX="$TMP_DIR/Packages.gz"
+
+cat > "$INDEX" <<'EOF'
+Package: cx-demo
+Version: 1.0
+Installed-Size: 30
+Depends: heavy-runtime | tiny-runtime, shared-lib
+Description: demo application
+
+Package: heavy-runtime
+Version: 1.0
+Installed-Size: 800
+Description: large runtime
+
+Package: tiny-runtime
+Version: 1.0
+Installed-Size: 45
+Provides: runtime-virtual
+Description: compact runtime
+
+Package: shared-lib
+Version: 2.0
+Installed-Size: 10
+Description: shared library
+
+Package: conflict-tool
+Version: 1.0
+Installed-Size: 5
+Conflicts: shared-lib
+Description: package that conflicts with the shared library
+
+Package: virtual-consumer
+Version: 1.0
+Installed-Size: 20
+Depends: runtime-virtual
+Description: virtual package consumer
+EOF
+
+gzip -c "$INDEX" > "$GZ_INDEX"
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "Expected output to contain: $needle" >&2
+        echo "$haystack" >&2
+        exit 1
+    fi
+}
+
+run_optimizer() {
+    "$ROOT_DIR/apt/scripts/optimize-dependency-tree.py" --index "$INDEX" "$@"
+}
+
+output="$(run_optimizer cx-demo)"
+assert_contains "$output" "Selected packages: 3"
+assert_contains "$output" "Total Installed-Size: 85 KiB"
+assert_contains "$output" "tiny-runtime 1.0"
+if [[ "$output" == *"heavy-runtime 1.0"* ]]; then
+    echo "Expected optimizer to choose tiny-runtime instead of heavy-runtime" >&2
+    echo "$output" >&2
+    exit 1
+fi
+assert_contains "$output" "Missing dependencies: none"
+assert_contains "$output" "Conflicts: none"
+
+output="$(run_optimizer --dot cx-demo)"
+assert_contains "$output" "digraph dependencies"
+assert_contains "$output" "\"cx-demo\" -> \"tiny-runtime\""
+
+output="$(run_optimizer virtual-consumer)"
+assert_contains "$output" "virtual-consumer 1.0"
+assert_contains "$output" "tiny-runtime 1.0"
+
+output="$(run_optimizer runtime-virtual)"
+assert_contains "$output" "- tiny-runtime"
+assert_contains "$output" "Total Installed-Size: 45 KiB"
+
+if run_optimizer cx-demo conflict-tool > "$TMP_DIR/conflict.out" 2>&1; then
+    echo "Expected conflicting plan to fail" >&2
+    cat "$TMP_DIR/conflict.out" >&2
+    exit 1
+fi
+assert_contains "$(cat "$TMP_DIR/conflict.out")" "conflict-tool conflicts with shared-lib"
+
+if run_optimizer missing-package > "$TMP_DIR/missing.out" 2>&1; then
+    echo "Expected missing dependency plan to fail" >&2
+    cat "$TMP_DIR/missing.out" >&2
+    exit 1
+fi
+assert_contains "$(cat "$TMP_DIR/missing.out")" "Missing dependencies:"
+
+output="$("$ROOT_DIR/apt/scripts/optimize-dependency-tree.py" --index "$GZ_INDEX" cx-demo)"
+assert_contains "$output" "Total Installed-Size: 85 KiB"
+
+echo "optimize-dependency-tree-test.sh: all assertions passed"

--- a/tests/optimize-dependency-tree-test.sh
+++ b/tests/optimize-dependency-tree-test.sh
@@ -95,6 +95,62 @@ Package: diamond-shared
 Version: 1.0
 Installed-Size: 1
 Description: shared dependency
+
+Package: versioned-root
+Version: 1.0
+Installed-Size: 1
+Depends: versioned-lib (>= 2.0)
+Description: package requiring a newer direct dependency
+
+Package: versioned-lib
+Version: 1.0
+Installed-Size: 1
+Description: incompatible older direct dependency
+
+Package: versioned-lib
+Version: 2.0
+Installed-Size: 20
+Description: compatible newer direct dependency
+
+Package: virtual-version-root
+Version: 1.0
+Installed-Size: 1
+Depends: virtual-api (>= 2.0)
+Description: package requiring a versioned virtual dependency
+
+Package: provider-old
+Version: 1.0
+Installed-Size: 1
+Provides: virtual-api (= 1.0)
+Description: incompatible virtual provider
+
+Package: provider-new
+Version: 1.0
+Installed-Size: 20
+Provides: virtual-api (= 2.0)
+Description: compatible virtual provider
+
+Package: marginal-root
+Version: 1.0
+Installed-Size: 1
+Depends: shared-parent, shared-runtime | tiny-alt
+Description: root with sibling dependencies sharing a runtime
+
+Package: shared-parent
+Version: 1.0
+Installed-Size: 1
+Depends: shared-runtime
+Description: parent that already pulls the shared runtime
+
+Package: shared-runtime
+Version: 1.0
+Installed-Size: 100
+Description: large runtime shared by siblings
+
+Package: tiny-alt
+Version: 1.0
+Installed-Size: 60
+Description: smaller standalone alternative before deduplication
 EOF
 
 gzip -c "$INDEX" > "$GZ_INDEX"
@@ -169,6 +225,19 @@ assert_contains "$(cat "$TMP_DIR/stale-provider.out")" "Missing dependencies:"
 output="$(run_optimizer diamond-root)"
 assert_contains "$output" "diamond-shared 1.0"
 assert_not_contains "$output" "(cycle skipped)"
+
+output="$(run_optimizer versioned-root)"
+assert_contains "$output" "versioned-lib 2.0"
+assert_not_contains "$output" "versioned-lib 1.0"
+
+output="$(run_optimizer virtual-version-root)"
+assert_contains "$output" "provider-new 1.0"
+assert_not_contains "$output" "provider-old 1.0"
+
+output="$(run_optimizer marginal-root)"
+assert_contains "$output" "Total Installed-Size: 102 KiB"
+assert_contains "$output" "shared-runtime 1.0"
+assert_not_contains "$output" "tiny-alt 1.0"
 
 if run_optimizer cx-demo conflict-tool > "$TMP_DIR/conflict.out" 2>&1; then
     echo "Expected conflicting plan to fail" >&2


### PR DESCRIPTION
## Summary
- add a read-only APT Packages/Packages.gz dependency tree optimizer
- choose the smallest dependency closure across alternatives and virtual package providers
- report missing dependencies/conflicts and optional Graphviz DOT output
- wire the optimizer test into the Makefile

Closes #26

## Verification
- python3 -m py_compile apt/scripts/optimize-dependency-tree.py
- bash -n tests/optimize-dependency-tree-test.sh
- bash tests/optimize-dependency-tree-test.sh
- make test-dep-tree-optimizer
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only tool to optimize APT dependency trees using local package indexes.
  * Reports selected packages, dependencies, installed size, missing dependencies, and conflicts.
  * Supports virtual packages, compressed indexes, custom index paths, and Graphviz DOT output.
  * Added version-aware dependency resolution, including versioned providers, conflicts, and breaks.
  * Improved package selection consistency when comparing versions and dependency alternatives.

* **Documentation**
  * Added usage instructions, supported index sources, report details, exit statuses, and test guidance.

* **Tests**
  * Added comprehensive end-to-end coverage for dependency resolution and optimizer output.
  * Added a Makefile target for running optimizer tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->